### PR TITLE
Image opacity modifications and widget documentation

### DIFF
--- a/src/engine/ui/widgets/Button.hxx
+++ b/src/engine/ui/widgets/Button.hxx
@@ -12,6 +12,10 @@ enum class TextLayout
   BOTTOM_LEFT,
   BOTTOM_RIGHT
 };
+
+/**
+ * @brief A Button GUI Widget
+ */
 class Button : public UIElement
 {
 public:
@@ -20,6 +24,10 @@ public:
 
   void draw() override;
 
+  /** @brief Sets the button's text
+   * sets the button's text to the string passed as an argument
+   * @param text the text to be displayed on the button
+   */
   void setText(const std::string &text);
 
   bool onMouseButtonUp(const SDL_Event &event) override;
@@ -42,6 +50,7 @@ public:
 private:
   SDL_Rect m_frameRect;
 
+  /// a pointer to the button's text
   std::unique_ptr<Text> m_buttonLabel;
 
   bool m_isMouseButtonDown = false;

--- a/src/engine/ui/widgets/Checkbox.hxx
+++ b/src/engine/ui/widgets/Checkbox.hxx
@@ -3,6 +3,9 @@
 
 #include "../basics/UIElement.hxx"
 
+/**
+ * @brief A Checkbox GUI Widget
+ */
 class Checkbox : public UIElement
 {
 public:

--- a/src/engine/ui/widgets/Combobox.hxx
+++ b/src/engine/ui/widgets/Combobox.hxx
@@ -31,6 +31,10 @@ public:
   * @return selected ID
   */
   int getActiveID() const { return m_activeID; };
+  /** @brief Set ID of selected element
+  * sets the ID of the selected element in the comboBox
+  * @param ID the value to set the ID to
+  */
   void setActiveID(int ID);
 
   size_t count() const { return m_textField->count(); };
@@ -38,13 +42,19 @@ public:
 
   void registerCallbackFunction(std::function<void(UIElement *sender)> const &cb) override;
 
+  /** @brief Clears the element's text field
+  * clears the text field of the comboBox
+  */
   void clear() { m_textField->clear(); }
 
 private:
+  /// the active element's ID
   int m_activeID = 0;
-  SDL_Rect m_dropDownRect;     // represents the dropdownMenu
-  SDL_Rect m_wholeElementRect; // represents the whole UIElement including the opened menu
-
+  /// represents the dropdownMenu
+  SDL_Rect m_dropDownRect;
+  /// represents the whole UIElement including the opened menu
+  SDL_Rect m_wholeElementRect;
+  /// pointer to the textField of this comboBox
   std::unique_ptr<TextField> m_textField;
 
   bool m_isMenuOpened = false;

--- a/src/engine/ui/widgets/Frame.hxx
+++ b/src/engine/ui/widgets/Frame.hxx
@@ -3,6 +3,9 @@
 
 #include "../basics/UIElement.hxx"
 
+/**
+ * @brief A Frame GUI Widget
+ */
 class Frame : public UIElement
 {
 public:

--- a/src/engine/ui/widgets/Image.hxx
+++ b/src/engine/ui/widgets/Image.hxx
@@ -5,6 +5,9 @@
 
 #include "../basics/UIElement.hxx"
 
+/**
+ * @brief An Image GUI Widget
+ */
 class Image : public UIElement
 {
 public:
@@ -13,9 +16,13 @@ public:
 
   void draw() override;
 
+  /** @brief sets the opacity of the image
+   * @param alphaLevel value from 0 to 255 that corresponds to image's opacity where 0 is transparent and 255 is opaque
+   */
   void setOpacity(Uint8 alphaLevel) { m_alphaLevel = alphaLevel; };
 
 private:
+  /// the alpha value of the image
   Uint8 m_alphaLevel = 255;
 };
 

--- a/src/engine/ui/widgets/Slider.hxx
+++ b/src/engine/ui/widgets/Slider.hxx
@@ -5,6 +5,9 @@
 
 #include "../basics/UIElement.hxx"
 
+/**
+ * @brief A Slider GUI Widget
+ */
 class Slider : public UIElement
 {
 public:

--- a/src/engine/ui/widgets/Text.hxx
+++ b/src/engine/ui/widgets/Text.hxx
@@ -38,6 +38,10 @@ public:
    */
   void setFontSize(int fontSize);
 
+  /** @brief gets the Font size of this element
+   * gets the font size of the element
+   * @returns the element's font size
+   */
   int getFontSize() const { return m_fontSize; }
 
 private:
@@ -49,6 +53,7 @@ private:
   */
   void createTextTexture(const std::string &text, const SDL_Color &textColor);
 
+  /// the font size of the text
   int m_fontSize = 20;
 };
 

--- a/src/engine/ui/widgets/TextField.hxx
+++ b/src/engine/ui/widgets/TextField.hxx
@@ -11,6 +11,9 @@ enum class TextFieldAlignment
   CENTERED
 };
 
+/**
+ * @brief A TextField GUI Widget
+ */
 class TextField : public UIElement
 {
 public:
@@ -47,7 +50,7 @@ private:
   size_t m_count = 0;
 
   std::vector<std::unique_ptr<Text>> m_textElements;
-
+  /// height of this element's text
   int m_textElementHeight = 0;
 
   // a rect is drawn beneath the current text to hover it

--- a/src/engine/ui/widgets/Tooltip.hxx
+++ b/src/engine/ui/widgets/Tooltip.hxx
@@ -18,12 +18,26 @@ public:
   ~Tooltip() override = default;
 
   void draw() override;
+
+  /** @brief starts the countdown to when the Tooltip appears
+   * starts the timer for the countdown to when the Tooltip becomes visible
+   */
   void startTimer();
+
+  /** @brief makes the Tooltip visible
+   * makes the Tooltip visible
+   */
   void showTooltip();
+
+  /** @brief resets the Tooltip
+   * Hides and deactivates the Tooltip and stops the timer
+   */
   void reset();
 
 private:
+  /// Timer that counts the time until the Tooltip should be displayed
   Timer m_tooltipTimer;
+  /// if the Tooltip is active or not
   bool m_active = false;
 };
 


### PR DESCRIPTION
The `setOpacity` method for the Image widget now checks if the alpha level given is between 0 and 255 before changing the opacity. If not, the method logs an error. 

Also added some documentation to UI widget classes.