### PR TITLE
Ui button tile images

### DIFF
--- a/data/resources/settings.json
+++ b/data/resources/settings.json
@@ -28,6 +28,8 @@
     "User Interface": {
         "BuildMenu Position": "BOTTOM",
         "Language": "en",
-        "Font Filename": "resources/fonts/arcadeclassics.ttf"
+        "Font Filename": "resources/fonts/arcadeclassics.ttf",
+        "SubMenuButtonWidth": 32,
+        "SubMenuButtonHeight": 32
     }
 }

--- a/src/engine/EventManager.cxx
+++ b/src/engine/EventManager.cxx
@@ -100,42 +100,46 @@ void EventManager::checkEvents(SDL_Event &event, Engine &engine)
       // check for UI events first
       for (const auto &it : m_uiManager.getAllUiElements())
       {
-        // spawn tooltip timer, if we're over an UI Element
-        if (it->isMouseOver(event.button.x, event.button.y) && !it->getUiElementData().tooltipText.empty())
+        // if element isn't visible then don't event check it
+        if (it->isVisible())
         {
-          m_uiManager.startTooltip(event, it->getUiElementData().tooltipText);
-        }
-        // if the mouse cursor left an element, we're not hovering any more and we need to reset the pointer to the last hovered element
-        if (m_lastHoveredElement && !m_lastHoveredElement->isMouseOverHoverableArea(event.button.x, event.button.y))
-        {
-          // we're not hovering, so stop the tooltips
-          m_uiManager.stopTooltip();
-          // tell the previously hovered element we left it before resetting it
-          m_lastHoveredElement->onMouseLeave(event);
-          m_lastHoveredElement = nullptr;
-          break;
-        }
-        // If we're over a UI element that has no click functionality, abort the event loop, so no clicks go through the UiElement.
-        //Note: This is handled here because UIGroups have no dimensions, but are UiElements
-        if (it->isMouseOverHoverableArea(event.button.x, event.button.y))
-        {
-          it->onMouseMove(event);
-          // if the element we're hovering over is not the same as the stored "lastHoveredElement", update it
-          if (it.get() != m_lastHoveredElement)
+          // spawn tooltip timer, if we're over an UI Element
+          if (it->isMouseOver(event.button.x, event.button.y) && !it->getUiElementData().tooltipText.empty())
           {
-            if (m_lastHoveredElement)
-            {
-              m_lastHoveredElement->onMouseLeave(event);
-            }
-            it->onMouseEnter(event);
-            m_lastHoveredElement = it.get();
+            m_uiManager.startTooltip(event, it->getUiElementData().tooltipText);
           }
-          break;
-        }
-        // definitely figure out a better way to do this, this was done for the Slider
-        if (it->isMouseOver(event.button.x, event.button.y))
-        {
-          it->onMouseMove(event);
+          // if the mouse cursor left an element, we're not hovering any more and we need to reset the pointer to null
+          if (m_lastHoveredElement && !m_lastHoveredElement->isMouseOverHoverableArea(event.button.x, event.button.y))
+          {
+            // we're not hovering, so stop the tooltips
+            m_uiManager.stopTooltip();
+            // tell the previously hovered element we left it before resetting it
+            m_lastHoveredElement->onMouseLeave(event);
+            m_lastHoveredElement = nullptr;
+            break;
+          }
+          // If we're over a UI element that has no click functionality, abort the event loop, so no clicks go through the UiElement.
+          //Note: This is handled here because UIGroups have no dimensions, but are UiElements
+          if (it->isMouseOverHoverableArea(event.button.x, event.button.y))
+          {
+            it->onMouseMove(event);
+            // if the element we're hovering over is not the same as the stored "lastHoveredElement", update it
+            if (it.get() != m_lastHoveredElement)
+            {
+              if (m_lastHoveredElement)
+              {
+                m_lastHoveredElement->onMouseLeave(event);
+              }
+              it->onMouseEnter(event);
+              m_lastHoveredElement = it.get();
+            }
+            break;
+          }
+          // definitely figure out a better way to do this, this was done for the Slider
+          if (it->isMouseOver(event.button.x, event.button.y))
+          {
+            it->onMouseMove(event);
+          }
         }
       }
 

--- a/src/engine/UIManager.cxx
+++ b/src/engine/UIManager.cxx
@@ -502,6 +502,24 @@ void UIManager::scaleCenterButtonImage(SDL_Rect &ret, int btnW, int btnH, int im
   }
 }
 
+void UIManager::setupButtonTileImage(Button *button, const std::pair<std::string, TileData>& tile)
+{
+  int bWid = Settings::instance().subMenuButtonWidth; //UI button width for sub menues
+  int bHei = Settings::instance().subMenuButtonHeight; //UI button height for sub menues
+
+  if (TileManager::instance().getTexture(tile.first, TileMap::DEFAULT) == nullptr)
+  {
+    button->setTextureID("Button_NoIcon");
+  }
+  SDL_Rect destRect{button->getUiElementRect().x, button->getUiElementRect().y, 0, 0}; 
+  scaleCenterButtonImage(destRect, bWid, bHei, tile.second.tiles.clippingWidth, tile.second.tiles.clippingHeight);
+  button->setTextureID(
+    TileManager::instance().getTexture(tile.first, TileMap::DEFAULT),
+    {0, 0, tile.second.tiles.clippingWidth, tile.second.tiles.clippingHeight},
+    destRect
+    );
+}
+
 void UIManager::createBuildMenu()
 {
   std::string subMenuSuffix = "_sub";
@@ -532,6 +550,7 @@ void UIManager::createBuildMenu()
   int bWid = Settings::instance().subMenuButtonWidth; //UI button width for sub menues
   int bHei = Settings::instance().subMenuButtonHeight; //UI button height for sub menues
 
+
   for (auto &tile : TileManager::instance().getAllTileData())
   {
     std::string category = tile.second.category;
@@ -554,17 +573,7 @@ void UIManager::createBuildMenu()
         }
         Button *button = new Button({0, 0, bWid, bHei});
 
-        if (TileManager::instance().getTexture(tile.first, TileMap::DEFAULT) == nullptr)
-        {
-          button->setTextureID("Button_NoIcon");
-        }
-        SDL_Rect destRect{button->getUiElementRect().x, button->getUiElementRect().y, 0, 0}; 
-        scaleCenterButtonImage(destRect, bWid, bHei, tile.second.tiles.clippingWidth, tile.second.tiles.clippingHeight);
-        button->setTextureID(
-          TileManager::instance().getTexture(tile.first, TileMap::DEFAULT),
-          {0, 0, tile.second.tiles.clippingWidth, tile.second.tiles.clippingHeight},
-          destRect
-          );
+        setupButtonTileImage(button, tile);
         button->drawImageButtonFrame(true);
         button->setVisibility(false);
         button->setToggleButton(true);
@@ -578,17 +587,7 @@ void UIManager::createBuildMenu()
       }
       Button *button = new Button({0, 0, bWid, bHei});
 
-      if (TileManager::instance().getTexture(tile.first, TileMap::DEFAULT) == nullptr)
-      {
-        button->setTextureID("Button_NoIcon");
-      }
-      SDL_Rect destRect{button->getUiElementRect().x, button->getUiElementRect().y, 0, 0}; 
-      scaleCenterButtonImage(destRect, bWid, bHei, tile.second.tiles.clippingWidth, tile.second.tiles.clippingHeight);
-      button->setTextureID(
-        TileManager::instance().getTexture(tile.first, TileMap::DEFAULT),
-        {0, 0, tile.second.tiles.clippingWidth, tile.second.tiles.clippingHeight},
-        destRect
-        );
+      setupButtonTileImage(button, tile);
       button->drawImageButtonFrame(true);
       button->setVisibility(false);
       button->setToggleButton(true);
@@ -603,17 +602,7 @@ void UIManager::createBuildMenu()
     {
       Button *button = new Button({0, 0, bWid, bHei});
 
-      if (TileManager::instance().getTexture(tile.first, TileMap::DEFAULT) == nullptr)
-      {
-        button->setTextureID("Button_NoIcon");
-      }
-      SDL_Rect destRect{button->getUiElementRect().x, button->getUiElementRect().y, 0, 0}; 
-      scaleCenterButtonImage(destRect, bWid, bHei, tile.second.tiles.clippingWidth, tile.second.tiles.clippingHeight);
-      button->setTextureID(
-        TileManager::instance().getTexture(tile.first, TileMap::DEFAULT),
-        {0, 0, tile.second.tiles.clippingWidth, tile.second.tiles.clippingHeight},
-        destRect
-        );
+      setupButtonTileImage(button, tile);
       button->drawImageButtonFrame(true);
       button->setVisibility(false);
       button->setToggleButton(true);

--- a/src/engine/UIManager.cxx
+++ b/src/engine/UIManager.cxx
@@ -225,6 +225,11 @@ void UIManager::init()
           {
             m_uiGroups[groupID].push_back(uiElement.get());
           }
+
+          if (uiElement->getUiElementData().elementID == "slider")
+          {
+            m_slider = dynamic_cast<Slider *>(uiElement.get());
+          }
         }
 
         if (!layoutGroupName.empty())
@@ -296,6 +301,10 @@ void UIManager::toggleGroupVisibility(const std::string &groupID, UIElement *sen
 
   if (sender)
   {
+    if (m_slider != nullptr)
+    {
+      m_slider->clearUiElements();
+    }
     Button *button = dynamic_cast<Button *>(sender);
     // cast the object to a Button to check if it's a toggle button.
     if (button && button->getUiElementData().isToggleButton)
@@ -303,6 +312,11 @@ void UIManager::toggleGroupVisibility(const std::string &groupID, UIElement *sen
       for (const auto &it : m_uiGroups[groupID])
       {
         it->setVisibility(button->checkState());
+        //toggle this group as the visible one in the slider
+        if (m_slider != nullptr)
+        {
+          m_slider->addUiElement(it);
+        }
       }
       return;
     }

--- a/src/engine/UIManager.cxx
+++ b/src/engine/UIManager.cxx
@@ -11,6 +11,8 @@
 #include "json.hxx"
 #include "betterEnums.hxx"
 
+#include <cmath>
+
 #ifdef MICROPROFILE_ENABLED
 #include "microprofile.h"
 #endif
@@ -466,6 +468,26 @@ void UIManager::setCallbackFunctions()
   }
 }
 
+void UIManager::scaleCenterButtonImage(SDL_Rect &ret, int btnW, int btnH, int imgW, int imgH)
+{
+  if (imgW > imgH)
+  {
+    float ratio = (float)imgH / (float)imgW;
+    ret.w = btnW;
+    ret.h = ceil(btnH * ratio);
+    ret.x = 0;
+    ret.y = btnH - ret.h;
+  }
+  else
+  {
+    float ratio = (float)imgW / (float)imgH;
+    ret.w = ceil(btnW * ratio);
+    ret.h = btnH;
+    ret.x = ceil((btnW - ret.w)/2);
+    ret.y = 0;
+  }
+}
+
 void UIManager::createBuildMenu()
 {
   std::string subMenuSuffix = "_sub";
@@ -492,6 +514,10 @@ void UIManager::createBuildMenu()
   // Add elements from TileData.json to the BuildMenu, if there is a button whose BuildMenuID matches the category
   // check if there's a corresponding category for tiles for this menu ID.
   int idx = 0;
+
+  int bWid = Settings::instance().subMenuButtonWidth; //UI button width for sub menues
+  int bHei = Settings::instance().subMenuButtonHeight; //UI button height for sub menues
+
   for (auto &tile : TileManager::instance().getAllTileData())
   {
     std::string category = tile.second.category;
@@ -512,9 +538,19 @@ void UIManager::createBuildMenu()
         {
           m_buttonGroups["Debug_sub"] = new ButtonGroup;
         }
-        Button *button = new Button({0, 0, 0, 0});
+        Button *button = new Button({0, 0, bWid, bHei});
 
-        button->setTextureID("Button_NoIcon");
+        if (TileManager::instance().getTexture(tile.first, TileMap::DEFAULT) == nullptr)
+        {
+          button->setTextureID("Button_NoIcon");
+        }
+        SDL_Rect destRect{button->getUiElementRect().x, button->getUiElementRect().y, 0, 0}; 
+        scaleCenterButtonImage(destRect, bWid, bHei, tile.second.tiles.clippingWidth, tile.second.tiles.clippingHeight);
+        button->setTextureID(
+          TileManager::instance().getTexture(tile.first, TileMap::DEFAULT),
+          {0, 0, tile.second.tiles.clippingWidth, tile.second.tiles.clippingHeight},
+          destRect
+          );
         button->drawImageButtonFrame(true);
         button->setVisibility(false);
         button->setToggleButton(true);
@@ -526,9 +562,19 @@ void UIManager::createBuildMenu()
         m_buttonGroups["Debug_sub"]->addToGroup(button);
         m_uiElements.push_back(std::unique_ptr<UIElement>(dynamic_cast<UIElement *>(button)));
       }
-      Button *button = new Button({0, 0, 0, 0});
+      Button *button = new Button({0, 0, bWid, bHei});
 
-      button->setTextureID("Button_NoIcon");
+      if (TileManager::instance().getTexture(tile.first, TileMap::DEFAULT) == nullptr)
+      {
+        button->setTextureID("Button_NoIcon");
+      }
+      SDL_Rect destRect{button->getUiElementRect().x, button->getUiElementRect().y, 0, 0}; 
+      scaleCenterButtonImage(destRect, bWid, bHei, tile.second.tiles.clippingWidth, tile.second.tiles.clippingHeight);
+      button->setTextureID(
+        TileManager::instance().getTexture(tile.first, TileMap::DEFAULT),
+        {0, 0, tile.second.tiles.clippingWidth, tile.second.tiles.clippingHeight},
+        destRect
+        );
       button->drawImageButtonFrame(true);
       button->setVisibility(false);
       button->setToggleButton(true);
@@ -541,12 +587,19 @@ void UIManager::createBuildMenu()
     }
     else
     {
-      Button *button = new Button({0, 0, 0, 0});
+      Button *button = new Button({0, 0, bWid, bHei});
 
-      // TODO: Check if icon empty.
-
-      // Set button properties
-      button->setTextureID("Button_NoIcon");
+      if (TileManager::instance().getTexture(tile.first, TileMap::DEFAULT) == nullptr)
+      {
+        button->setTextureID("Button_NoIcon");
+      }
+      SDL_Rect destRect{button->getUiElementRect().x, button->getUiElementRect().y, 0, 0}; 
+      scaleCenterButtonImage(destRect, bWid, bHei, tile.second.tiles.clippingWidth, tile.second.tiles.clippingHeight);
+      button->setTextureID(
+        TileManager::instance().getTexture(tile.first, TileMap::DEFAULT),
+        {0, 0, tile.second.tiles.clippingWidth, tile.second.tiles.clippingHeight},
+        destRect
+        );
       button->drawImageButtonFrame(true);
       button->setVisibility(false);
       button->setToggleButton(true);

--- a/src/engine/UIManager.hxx
+++ b/src/engine/UIManager.hxx
@@ -150,6 +150,8 @@ private:
   UIManager() = default;
   ~UIManager() = default;
 
+  Slider *m_slider = nullptr;
+
   // this container holds all UiElements and is the owner.
   std::vector<std::unique_ptr<UIElement>> m_uiElements;
 

--- a/src/engine/UIManager.hxx
+++ b/src/engine/UIManager.hxx
@@ -176,6 +176,7 @@ private:
   void scaleCenterButtonImage(SDL_Rect &ret, int btnW, int btnH, int imgW, int imgH);
   void createBuildMenu();
   void setBuildMenuLayout();
+  void setupButtonTileImage(Button *button, const std::pair<std::string, TileData>& tile);
 
   bool m_showDebugMenu = false;
 

--- a/src/engine/UIManager.hxx
+++ b/src/engine/UIManager.hxx
@@ -171,7 +171,7 @@ private:
   std::unique_ptr<Text> m_fpsCounter = std::make_unique<Text>();
 
   void setCallbackFunctions();
-
+  void scaleCenterButtonImage(SDL_Rect &ret, int btnW, int btnH, int imgW, int imgH);
   void createBuildMenu();
   void setBuildMenuLayout();
 

--- a/src/engine/basics/Settings.hxx
+++ b/src/engine/basics/Settings.hxx
@@ -140,6 +140,19 @@ struct SettingsData
    * @brief FilePath of the Font that should be used.
    */
   FilePath fontFileName;
+
+  /**
+   * @brief The width in pixels of the buttons used in the 
+   * build sub menues on the UI
+   */
+  int subMenuButtonWidth;
+
+  /**
+   * @brief The height in pixels of the buttons used in the 
+   * build sub menues on the UI
+   */
+  int subMenuButtonHeight;
+
 };
 
 /**

--- a/src/engine/common/JsonSerialization.hxx
+++ b/src/engine/common/JsonSerialization.hxx
@@ -46,6 +46,8 @@ inline void from_json(const json &j, SettingsData &s)
   s.buildMenuPosition = j["User Interface"].value("BuildMenu Position", "BOTTOM");
   s.gameLanguage = j["User Interface"].value("Language", "en");
   s.fontFileName = j["User Interface"].value("Font Filename", "en");
+  s.subMenuButtonWidth = j["User Interface"].value("SubMenuButtonWidth", 32);
+  s.subMenuButtonHeight = j["User Interface"].value("SubMenuButtonHeight", 32);
 }
 
 // JSON deserializer for BiomeData struct (Terrain Gen)

--- a/src/engine/ui/basics/UIElement.cxx
+++ b/src/engine/ui/basics/UIElement.cxx
@@ -12,12 +12,21 @@ void UIElement::setTextureID(const std::string &textureID)
     return;
   }
   m_texture = texture;
+  m_directTexture = false;
   SDL_QueryTexture(m_texture, nullptr, nullptr, &m_uiElementRect.w, &m_uiElementRect.h);
+}
+
+void UIElement::setTextureID(SDL_Texture *texture, const SDL_Rect &clipRect, const SDL_Rect &textureRect)
+{
+  m_texture = texture; 
+  m_directTexture = true;
+  m_uiElementClipRect = clipRect;
+  m_uiTextureRect = textureRect;
 }
 
 void UIElement::changeButtonState(int state)
 {
-  if (m_buttonState != state && !elementData.textureID.empty())
+  if (m_buttonState != state && !elementData.textureID.empty() && m_directTexture == false)
   {
     changeTexture(ResourcesManager::instance().getUITexture(elementData.textureID, state));
   }
@@ -28,7 +37,18 @@ void UIElement::renderTexture() const
 {
   if (m_texture)
   {
-    SDL_RenderCopy(m_renderer, m_texture, nullptr, &m_uiElementRect);
+    if (m_directTexture) //if this texture was set directly then add the clipping rect
+    {
+      SDL_Rect newRect{m_uiElementRect.x + m_uiTextureRect.x,
+                       m_uiElementRect.y + m_uiTextureRect.y, 
+                       m_uiTextureRect.w, 
+                       m_uiTextureRect.h};
+      SDL_RenderCopy(m_renderer, m_texture, &m_uiElementClipRect, &newRect);
+    } 
+    else //otherwise, leave it as null and it'll figure itself out
+    {
+      SDL_RenderCopy(m_renderer, m_texture, nullptr, &m_uiElementRect);
+    }
   }
 }
 

--- a/src/engine/ui/basics/UIElement.hxx
+++ b/src/engine/ui/basics/UIElement.hxx
@@ -153,6 +153,9 @@ public:
   */
   void setTextureID(const std::string &textureID);
 
+  //Just incase you want to set the texture directly
+  void setTextureID(SDL_Texture *texture, const SDL_Rect &clipRect, const SDL_Rect &textureRect);
+
   void setParent(UIElement *parent) { elementData.parent = parent; };
   void setMenuGroupID(const std::string &buildMenuID) { elementData.buildMenuID = buildMenuID; };
   void setLayoutGroupName(const std::string &layoutGroupName) { elementData.layoutGroupName = layoutGroupName; };
@@ -171,9 +174,13 @@ private:
 
   bool m_visible = true;
 
+  bool m_directTexture = false; //was this texture set directly?
+
 protected:
   SDL_Texture *m_texture = nullptr;  /// a pointer to the element's texture
   SDL_Rect m_uiElementRect{0, 0, 0, 0};
+  SDL_Rect m_uiElementClipRect{0, 0, 0, 0};
+  SDL_Rect m_uiTextureRect{0, 0, 0, 0};
 
   void renderTexture() const;
 

--- a/src/engine/ui/basics/UIElement.hxx
+++ b/src/engine/ui/basics/UIElement.hxx
@@ -66,11 +66,18 @@ public:
     m_uiElementRect.y = y;
   };
 
+  virtual void setBasePosition(int x, int y)
+  {
+    m_uiBaseElementRect.x = x;
+    m_uiBaseElementRect.y = y;
+  };
+
   /** \brief Get the position and the size of this ui element
   * Gets the position and the size of this ui element
   * @return Position and size as SDL_Rect
   */
   const SDL_Rect &getUiElementRect() const { return m_uiElementRect; };
+  const SDL_Rect &getUiBaseElementRect() const { return m_uiBaseElementRect; };
 
   /** \brief Checks if the mouse cursor is over the current UI Element
   * Check if the coordinates match the ones stored in m_uiElementRect
@@ -181,6 +188,7 @@ protected:
   SDL_Rect m_uiElementRect{0, 0, 0, 0};
   SDL_Rect m_uiElementClipRect{0, 0, 0, 0};
   SDL_Rect m_uiTextureRect{0, 0, 0, 0};
+  SDL_Rect m_uiBaseElementRect{0, 0, 0, 0}; //the location of this element before sliding
 
   void renderTexture() const;
 

--- a/src/engine/ui/widgets/Slider.cxx
+++ b/src/engine/ui/widgets/Slider.cxx
@@ -29,6 +29,7 @@ void Slider::setValue(int val)
   // translate that to position on the slider (For the button)
   sliderButton.x = x - sliderButton.w / 2;
   curVal = val;
+  lastVal = val;
 }
 
 int Slider::getValue(int x)
@@ -82,7 +83,44 @@ void Slider::onMouseMove(const SDL_Event &event)
       sliderButton.x = event.motion.x - sliderButton.w / 2;
       curVal = getValue(event.motion.x);
     }
+    for(auto elem : m_uiElements)
+    {
+      SDL_Rect r = elem->getUiElementRect();
+      elem->setPosition(r.y, r.x - lastVal + curVal);
+      lastVal = curVal;
+    }
   }
 }
 
 bool Slider::isMouseOver(int x, int y) { return overSliderButton(x, y) || overSliderLine(x, y); }
+
+void Slider::addUiElement(UIElement *elem){
+  //change scrollRect so that it encoumpasses all elements in m_uiElements including this new one
+  SDL_Rect r = elem->getUiElementRect();
+  if (!scrollRectSet)
+  {
+    scrollRect = {r.x, r.y, r.w, r.h};
+  }
+  else
+  {
+    scrollRect.x = r.x < scrollRect.x ? r.x : scrollRect.x;
+    scrollRect.y = r.y < scrollRect.y ? r.y : scrollRect.y;
+    scrollRect.w = r.x + r.w > scrollRect.x + scrollRect.w ? r.x + r.w - scrollRect.x : scrollRect.w;
+    scrollRect.h = r.y + r.h > scrollRect.y + scrollRect.h ? r.y + r.h - scrollRect.y : scrollRect.h;
+  }
+
+  m_minVal = scrollRect.x;
+  m_maxVal = scrollRect.x + scrollRect.w;
+  setValue(scrollRect.w / 2); //set initial value as the middle (this should be calculated somehow)
+
+  //add the new element to m_uiElements
+  m_uiElements.push_back(elem);
+};
+
+void Slider::addUiElements(std::vector<UIElement *> newElems) 
+{ 
+  for(auto elem : newElems)
+  {
+    addUiElement(elem);
+  }
+}

--- a/src/engine/ui/widgets/Slider.cxx
+++ b/src/engine/ui/widgets/Slider.cxx
@@ -1,4 +1,6 @@
 #include "Slider.hxx"
+#include "../basics/LOG.hxx"
+#include "Settings.hxx"
 
 Slider::Slider(const SDL_Rect &uiElementRect) : UIElement(uiElementRect)
 {
@@ -29,7 +31,6 @@ void Slider::setValue(int val)
   // translate that to position on the slider (For the button)
   sliderButton.x = x - sliderButton.w / 2;
   curVal = val;
-  lastVal = val;
 }
 
 int Slider::getValue(int x)
@@ -57,6 +58,14 @@ bool Slider::onMouseButtonDown(const SDL_Event &event)
   {
     sliderButton.x = event.button.x - sliderButton.w / 2; // sets the middle of the button to where the user clicked
     curVal = getValue(event.button.x);
+    
+    //move all the elements being slid by this slider
+    for(auto elem : m_uiElements)
+    {
+      SDL_Rect r = elem->getUiBaseElementRect();
+      elem->setPosition(r.x + curVal - m_maxVal/2, r.y);
+    }
+
     return true;
   }
   if (overSliderButton(event.button.x, event.button.y))
@@ -83,11 +92,12 @@ void Slider::onMouseMove(const SDL_Event &event)
       sliderButton.x = event.motion.x - sliderButton.w / 2;
       curVal = getValue(event.motion.x);
     }
+
+    //move all the elements being slid by this slider
     for(auto elem : m_uiElements)
     {
-      SDL_Rect r = elem->getUiElementRect();
-      elem->setPosition(r.y, r.x - lastVal + curVal);
-      lastVal = curVal;
+      SDL_Rect r = elem->getUiBaseElementRect();
+      elem->setPosition(r.x + curVal - m_maxVal/2, r.y);
     }
   }
 }
@@ -95,26 +105,10 @@ void Slider::onMouseMove(const SDL_Event &event)
 bool Slider::isMouseOver(int x, int y) { return overSliderButton(x, y) || overSliderLine(x, y); }
 
 void Slider::addUiElement(UIElement *elem){
-  //change scrollRect so that it encoumpasses all elements in m_uiElements including this new one
-  SDL_Rect r = elem->getUiElementRect();
-  if (!scrollRectSet)
-  {
-    scrollRect = {r.x, r.y, r.w, r.h};
-  }
-  else
-  {
-    scrollRect.x = r.x < scrollRect.x ? r.x : scrollRect.x;
-    scrollRect.y = r.y < scrollRect.y ? r.y : scrollRect.y;
-    scrollRect.w = r.x + r.w > scrollRect.x + scrollRect.w ? r.x + r.w - scrollRect.x : scrollRect.w;
-    scrollRect.h = r.y + r.h > scrollRect.y + scrollRect.h ? r.y + r.h - scrollRect.y : scrollRect.h;
-  }
-
-  m_minVal = scrollRect.x;
-  m_maxVal = scrollRect.x + scrollRect.w;
-  setValue(scrollRect.w / 2); //set initial value as the middle (this should be calculated somehow)
-
   //add the new element to m_uiElements
+  elem->setBasePosition(elem->getUiElementRect().x, elem->getUiElementRect().y);
   m_uiElements.push_back(elem);
+  m_maxVal = m_maxVal + Settings::instance().subMenuButtonWidth * 1.5;
 };
 
 void Slider::addUiElements(std::vector<UIElement *> newElems) 
@@ -123,4 +117,14 @@ void Slider::addUiElements(std::vector<UIElement *> newElems)
   {
     addUiElement(elem);
   }
+}
+
+void Slider::clearUiElements() 
+{
+  for(auto elem : m_uiElements)
+  {
+    elem->setPosition(elem->getUiBaseElementRect().x, elem->getUiBaseElementRect().y);
+  }
+  m_uiElements.clear(); 
+  m_maxVal = 0; 
 }

--- a/src/engine/ui/widgets/Slider.hxx
+++ b/src/engine/ui/widgets/Slider.hxx
@@ -57,6 +57,14 @@ public:
    */
   bool isMouseOver(int, int) override;
 
+  /** @brief add uiElements to be controlled by this slider
+   * @param add uiElements to the vector of elements that will be controlled by this slider
+   */
+  void addUiElement(UIElement *elem);
+  void addUiElements(std::vector<UIElement *>);
+  void clearUiElements() {m_uiElements.clear(); scrollRectSet = false; };
+
+
 private:
   /// Thickness of the slider line
   int m_lineThickness = 6;
@@ -72,6 +80,13 @@ private:
   int curVal;
   /// whether or not the button is to follow the mouse
   bool dragMode;
+
+  // the elements to scroll
+  std::vector<UIElement *> m_uiElements;
+  // the rect that contains all the scrollable elements
+  SDL_Rect scrollRect;
+  bool scrollRectSet = false;
+  int lastVal;
 };
 
 #endif

--- a/src/engine/ui/widgets/Slider.hxx
+++ b/src/engine/ui/widgets/Slider.hxx
@@ -62,7 +62,7 @@ public:
    */
   void addUiElement(UIElement *elem);
   void addUiElements(std::vector<UIElement *>);
-  void clearUiElements() {m_uiElements.clear(); scrollRectSet = false; };
+  void clearUiElements();
 
 
 private:
@@ -75,7 +75,7 @@ private:
   /// minimum slider value
   int m_minVal = 0;
   /// maximum slider value
-  int m_maxVal = 100;
+  int m_maxVal = 0;
   /// current slider value
   int curVal;
   /// whether or not the button is to follow the mouse
@@ -83,10 +83,6 @@ private:
 
   // the elements to scroll
   std::vector<UIElement *> m_uiElements;
-  // the rect that contains all the scrollable elements
-  SDL_Rect scrollRect;
-  bool scrollRectSet = false;
-  int lastVal;
 };
 
 #endif

--- a/src/engine/ui/widgets/Tooltip.cxx
+++ b/src/engine/ui/widgets/Tooltip.cxx
@@ -3,7 +3,7 @@
 Tooltip::Tooltip()
 {
   m_tooltipTimer.registerCallbackFunction(Signal::slot(this, &Tooltip::showTooltip));
-  m_tooltipTimer.setTimer(1500);
+  m_tooltipTimer.setTimer(700);
   setVisibility(false);
 }
 


### PR DESCRIPTION
This branch adds the images of the buildings onto the buttons in the menus, so you can see what you're placing. It also makes the slider slide the menues around so that you can access all the tiles in the menues. The internal length of the slider is dynamic so you should be able to see all the buttons on any menu. I have also reduced the time for the tooltips. 

To test this, build this branch and run Cytopia. In a new game you should see the images of each building on the buttons, and they should look like small versions of themselves (Not weird super wide or stretched versions of themselves). Also the slider should give you access to the buttons either end of the res, com and ind menues.