### PR TITLE
Fix sound startup

### DIFF
--- a/src/Game.cxx
+++ b/src/Game.cxx
@@ -210,6 +210,10 @@ void Game::run(bool SkipMenu)
   scriptEngine.init();
 #endif
 
+#ifdef USE_SDL2_MIXER
+  m_AudioMixer.play(AudioTrigger::MainTheme);
+#endif
+
   // FPS Counter variables
   const float fpsIntervall = 1.0; // interval the fps counter is refreshed in seconds.
   Uint32 fpsLastTime = SDL_GetTicks();

--- a/src/Game.cxx
+++ b/src/Game.cxx
@@ -210,10 +210,6 @@ void Game::run(bool SkipMenu)
   scriptEngine.init();
 #endif
 
-#ifdef USE_SDL2_MIXER
-  m_AudioMixer.play(AudioTrigger::MainTheme);
-#endif
-
   // FPS Counter variables
   const float fpsIntervall = 1.0; // interval the fps counter is refreshed in seconds.
   Uint32 fpsLastTime = SDL_GetTicks();
@@ -268,6 +264,7 @@ void Game::shutdown()
   TTF_Quit();
 
 #ifdef USE_SDL2_MIXER
+  m_AudioMixer.joinLoadThread();
   Mix_Quit();
 #endif
 

--- a/src/Game.hxx
+++ b/src/Game.hxx
@@ -16,7 +16,6 @@
 #include "engine/basics/LOG.hxx"
 
 #include <thread>
-#include <iostream>
 
 using Thread = std::thread;
 using RuntimeError = std::runtime_error;

--- a/src/Game.hxx
+++ b/src/Game.hxx
@@ -16,6 +16,7 @@
 #include "engine/basics/LOG.hxx"
 
 #include <thread>
+#include <iostream>
 
 using Thread = std::thread;
 using RuntimeError = std::runtime_error;

--- a/src/services/AudioMixer.hxx
+++ b/src/services/AudioMixer.hxx
@@ -11,6 +11,8 @@
 #include "../GameService.hxx"
 #include "../util/Meta.hxx"
 
+#include <thread>
+
 template <typename Key, typename Value> 
 using Mapping = std::unordered_map<Key, Value>;
 template <typename Type, size_t N>
@@ -92,6 +94,16 @@ public:
   AudioMixer(GameService::ServiceTuple&);
   ~AudioMixer();
 
+  /**
+   * @brief Loads all game sounds, can be called in new thread
+   */
+  void loadAllSounds();
+
+  /**
+   * @brief joins the thread used to load sounds, if its still running
+   */
+  void joinLoadThread();
+
 private:
 
   /**
@@ -113,6 +125,11 @@ private:
    * @brief All the currently playing Soundtracks
    */
   List<SoundtrackUPtr*> m_Playing;
+
+  /**
+   * @brief A separate thread for loading the sounds.
+   */
+  std::thread m_LoadSoundThread;
 
   /* Event handlers */
   void handleEvent(const AudioTriggerEvent&& event);

--- a/src/services/AudioMixer.hxx
+++ b/src/services/AudioMixer.hxx
@@ -101,6 +101,8 @@ public:
 
   /**
    * @brief joins the thread used to load sounds, if its still running
+   *        This must be called when all other threads are joining
+   *        when the application is closing, or else it won't close nicely.
    */
   void joinLoadThread();
 
@@ -130,6 +132,12 @@ private:
    * @brief A separate thread for loading the sounds.
    */
   std::thread m_LoadSoundThread;
+
+  /**
+   * @brief if this becomes false then loading will stop.
+   *        it will be made false by the joinLoadThread function.
+   */
+  bool running = true;
 
   /* Event handlers */
   void handleEvent(const AudioTriggerEvent&& event);


### PR DESCRIPTION
This branch fixes the issues with the slow startup when loading the sounds. It would be best to be reviewed by someone who was having issues with the sound loading blocking the startup of the UI thread.
I have started a new thread in the AudioMixer that will free up the UI thread while the sounds are loading. This allows the game to start instantly again, however, this thread only ends once all sounds have loaded and it will block the game quitting while waiting for it to join, so basically I have moved the problem from when you start the game to when you are quitting the game but from a usability perspective, this is better (it definitely isn't worse). 

To test this; start the game, does it start quickly? when you start a new game, make sure the main theme music still plays.