### PR TITLE
Cleanup

### DIFF
--- a/data/resources/data/UILayout.json
+++ b/data/resources/data/UILayout.json
@@ -27,14 +27,6 @@
   "UiElements": {
     "Test": [      {
       "GroupVisibility": true
-    },
-    {
-      "ID": "slider",
-      "Type": "Slider",
-      "Position_x": 400,
-      "Position_y": 520,
-      "Width": 200,
-      "Height": 40
     }
   ],
     "BottomBar": [

--- a/src/engine/ui/widgets/Text.cxx
+++ b/src/engine/ui/widgets/Text.cxx
@@ -19,7 +19,6 @@ void Text::draw()
 void Text::setText(const std::string &text)
 {
 #ifdef USE_MOFILEREADER
-  LOG(LOG_INFO) << "Translatable string: " << text;
   elementData.text = moFileLib::moFileReaderSingleton::GetInstance().Lookup(text.c_str());
 #else
   elementData.text = text;


### PR DESCRIPTION
Removed the annoying "Translatable String" debug output.
Removed the test - slider that was always visible