### PR TITLE
Fix Github links still having JimmySnails in URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ Conan
 
 #### Build instructions
 
-See: <https://github.com/JimmySnails/Cytopia/wiki/Build-instructions>
+See: <https://github.com/CytopiaTeam/Cytopia/wiki/Build-instructions>
 
 #### Coding guidelines
 
-See: <https://github.com/JimmySnails/Cytopia/wiki/Coding-guidelines>
+See: <https://github.com/CytopiaTeam/Cytopia/wiki/Coding-guidelines>
 
 #### Work-in-Progress Screenshot
 


### PR DESCRIPTION
The build instructions and coding guidelines links were still mentioning the original name of the repo.