### PR TITLE
Camera Panning with WASD keys, bounds included

### DIFF
--- a/src/engine/EventManager.cxx
+++ b/src/engine/EventManager.cxx
@@ -61,36 +61,44 @@ void EventManager::checkEvents(SDL_Event &event, Engine &engine)
         break;
       case SDLK_w:
       {
+		  if(Camera::cameraOffset.y > -2*Settings::instance().screenHeight*Camera::zoomLevel)
+		  {
+			  Camera::cameraOffset.y -= (Settings::instance().screenHeight / 4);
+			  if (Engine::instance().map != nullptr){Engine::instance().map->refresh();}
+		  }
 		  
-		  Camera::cameraOffset.y -= (Settings::instance().screenHeight / 4);
-		  if (Engine::instance().map != nullptr){Engine::instance().map->refresh();}
-		 	
 		  break;
 	  }
 		
       case SDLK_a:
       {
-		  
-		  Camera::cameraOffset.x -= (Settings::instance().screenWidth / 4);
-		  if (Engine::instance().map != nullptr){Engine::instance().map->refresh();}
+		  if(Camera::cameraOffset.x > -0.25*Settings::instance().screenWidth*Camera::zoomLevel)
+		  {
+			  Camera::cameraOffset.x -= (Settings::instance().screenWidth / 4);
+		      if (Engine::instance().map != nullptr){Engine::instance().map->refresh();}
+		  }
 		  
 		  break;
 	  }
 		
 	  case SDLK_s:
 	  {
-		  
-		  Camera::cameraOffset.y += (Settings::instance().screenHeight / 4);
-	      if (Engine::instance().map != nullptr){Engine::instance().map->refresh();}
+		  if(Camera::cameraOffset.y < 1.25*Settings::instance().screenHeight*Camera::zoomLevel)
+		  {
+			  Camera::cameraOffset.y += (Settings::instance().screenHeight / 4);
+			  if (Engine::instance().map != nullptr){Engine::instance().map->refresh();}
+		  }
 		  
 		  break;
 	  }  
 	    
 	  case SDLK_d:
 	  {
-		  
-		  Camera::cameraOffset.x += (Settings::instance().screenWidth / 4);
-		  if (Engine::instance().map != nullptr){Engine::instance().map->refresh();}
+		  if(Camera::cameraOffset.x < 5*Settings::instance().screenWidth*Camera::zoomLevel)
+		  {
+			  Camera::cameraOffset.x += (Settings::instance().screenWidth / 4);
+			  if (Engine::instance().map != nullptr){Engine::instance().map->refresh();}
+		  }
 		
 	      break;
 	  }

--- a/src/engine/EventManager.cxx
+++ b/src/engine/EventManager.cxx
@@ -59,7 +59,43 @@ void EventManager::checkEvents(SDL_Event &event, Engine &engine)
       case SDLK_f:
         engine.toggleFullScreen();
         break;
-
+      case SDLK_w:
+      {
+		  
+		  Camera::cameraOffset.y -= (Settings::instance().screenHeight / 4);
+		  if (Engine::instance().map != nullptr){Engine::instance().map->refresh();}
+		 	
+		  break;
+	  }
+		
+      case SDLK_a:
+      {
+		  
+		  Camera::cameraOffset.x -= (Settings::instance().screenWidth / 4);
+		  if (Engine::instance().map != nullptr){Engine::instance().map->refresh();}
+		  
+		  break;
+	  }
+		
+	  case SDLK_s:
+	  {
+		  
+		  Camera::cameraOffset.y += (Settings::instance().screenHeight / 4);
+	      if (Engine::instance().map != nullptr){Engine::instance().map->refresh();}
+		  
+		  break;
+	  }  
+	    
+	  case SDLK_d:
+	  {
+		  
+		  Camera::cameraOffset.x += (Settings::instance().screenWidth / 4);
+		  if (Engine::instance().map != nullptr){Engine::instance().map->refresh();}
+		
+	      break;
+	  }
+	    
+	    
       default:
         break;
       }

--- a/src/engine/EventManager.cxx
+++ b/src/engine/EventManager.cxx
@@ -60,49 +60,35 @@ void EventManager::checkEvents(SDL_Event &event, Engine &engine)
         engine.toggleFullScreen();
         break;
       case SDLK_w:
-      {
 		  if(Camera::cameraOffset.y > -2*Settings::instance().screenHeight*Camera::zoomLevel)
 		  {
 			  Camera::cameraOffset.y -= (Settings::instance().screenHeight / 4);
 			  if (Engine::instance().map != nullptr){Engine::instance().map->refresh();}
 		  }
-		  
 		  break;
-	  }
-		
       case SDLK_a:
-      {
 		  if(Camera::cameraOffset.x > -0.25*Settings::instance().screenWidth*Camera::zoomLevel)
 		  {
 			  Camera::cameraOffset.x -= (Settings::instance().screenWidth / 4);
 		      if (Engine::instance().map != nullptr){Engine::instance().map->refresh();}
 		  }
-		  
 		  break;
-	  }
 		
 	  case SDLK_s:
-	  {
 		  if(Camera::cameraOffset.y < 1.25*Settings::instance().screenHeight*Camera::zoomLevel)
 		  {
 			  Camera::cameraOffset.y += (Settings::instance().screenHeight / 4);
 			  if (Engine::instance().map != nullptr){Engine::instance().map->refresh();}
 		  }
-		  
 		  break;
-	  }  
 	    
 	  case SDLK_d:
-	  {
 		  if(Camera::cameraOffset.x < 5*Settings::instance().screenWidth*Camera::zoomLevel)
 		  {
 			  Camera::cameraOffset.x += (Settings::instance().screenWidth / 4);
 			  if (Engine::instance().map != nullptr){Engine::instance().map->refresh();}
 		  }
-		
 	      break;
-	  }
-	    
 	    
       default:
         break;


### PR DESCRIPTION
This update adds camera panning with WASD keys.
Camera panning has boundaries that it cannot go past.

The boundaries generally work for different zoom levels, but depends on screen width and screen height.

Boundaries aren't included for the other panning methods.