### PR TITLE
Fixing mistake in 3D audio

### DIFF
--- a/src/Game.cxx
+++ b/src/Game.cxx
@@ -93,8 +93,7 @@ void Game::mainMenu()
   else
   {
 	//playing song in stereo with left and right locations, behind listener
-	m_AudioMixer.play(AudioTrigger::MainMenu,Coordinate3D{-2,0,1});
-	m_AudioMixer.play(AudioTrigger::MainMenu,Coordinate3D{2,0,1});
+	m_AudioMixer.play(AudioTrigger::MainMenu,Coordinate3D{0,3,0.5});
   }
   
   
@@ -269,8 +268,8 @@ void Game::run(bool SkipMenu)
   else
   {
 	//playing song in stereo with left and right locations
-	m_GameClock.createRepeatedTask(8min, [this]() { m_AudioMixer.play(AudioTrigger::MainTheme,Coordinate3D{2, 0, 1}); });
-	m_GameClock.createRepeatedTask(8min, [this]() { m_AudioMixer.play(AudioTrigger::MainTheme,Coordinate3D{-2, 0, 1}); });
+	
+	m_GameClock.createRepeatedTask(8min, [this]() { m_AudioMixer.play(AudioTrigger::MainMenu,Coordinate3D{0,0.5,0.1}); });
 	m_GameClock.createRepeatedTask(3min, [this]() { m_AudioMixer.play(AudioTrigger::NatureSounds,Coordinate3D{0, 0, -2}); });
   }
   

--- a/src/Game.cxx
+++ b/src/Game.cxx
@@ -269,7 +269,7 @@ void Game::run(bool SkipMenu)
   {
 	//playing song in stereo with left and right locations
 	
-	m_GameClock.createRepeatedTask(8min, [this]() { m_AudioMixer.play(AudioTrigger::MainMenu,Coordinate3D{0,0.5,0.1}); });
+	m_GameClock.createRepeatedTask(8min, [this]() { m_AudioMixer.play(AudioTrigger::MainTheme,Coordinate3D{0,0.5,0.1}); });
 	m_GameClock.createRepeatedTask(3min, [this]() { m_AudioMixer.play(AudioTrigger::NatureSounds,Coordinate3D{0, 0, -2}); });
   }
   

--- a/src/services/AudioMixer.cxx
+++ b/src/services/AudioMixer.cxx
@@ -142,6 +142,7 @@ void AudioMixer::play(AudioTrigger &&trigger, Coordinate3D &&position) noexcept
 {
   GetService<GameLoopMQ>().push(AudioTrigger3DEvent{trigger, position});
 }
+
 #endif
 
 void AudioMixer::setMuted(bool isMuted) noexcept { GetService<GameLoopMQ>().push(AudioSetMutedEvent{isMuted}); }
@@ -278,6 +279,8 @@ void AudioMixer::playSoundtrack(SoundtrackUPtr &track)
   m_Playing.push_front(&track);
   track->isPlaying = true;
 }
+
+
 
 void AudioMixer::onTrackFinished(int channelID)
 {

--- a/src/services/AudioMixer.hxx
+++ b/src/services/AudioMixer.hxx
@@ -75,6 +75,7 @@ public:
    */
 #ifdef USE_OPENAL_SOFT
   void play(AudioTrigger &&trigger, Coordinate3D &&position) noexcept;
+  
 #endif
   /**
    * @brief stops all sounds


### PR DESCRIPTION
I made a mistake of calling 2 triggers to play music at 2 different locations. I thought this would play the same song and it did when I tested it. 

However, it plays 2 different songs at 2 locations.

I removed this and just placed the music at one location that is more comfortable to hear.