### PR TITLE
occupied tile highlight fix, highlight all nodes of existing object.

### DIFF
--- a/src/engine/EventManager.cxx
+++ b/src/engine/EventManager.cxx
@@ -297,9 +297,15 @@ void EventManager::checkEvents(SDL_Event &event, Engine &engine)
                 if (!engine.map->checkTileIDIsEmpty(coords, tileTypeEditMode))
                 {
                   Point origCornerPoint = engine.map->getNodeOrigCornerPoint(coords);
-                  engine.map->highlightNode(origCornerPoint, SpriteHighlightColor::RED);
+                  Layer layer = TileManager::instance().getTileLayer(tileTypeEditMode);
+                  std::string currentTileID = engine.map->getTileID(origCornerPoint, layer);
+                  std::vector<Point> objectTiles = engine.map->getObjectCoords(origCornerPoint, currentTileID);
+                  for (auto objectCoordinate : objectTiles)
+                  {
+                    engine.map->highlightNode(objectCoordinate, SpriteHighlightColor::RED);
+                    pointsToHighlight.push_back(objectCoordinate);
+                  }
                   engine.map->highlightNode(coords, SpriteHighlightColor::RED);
-                  pointsToHighlight.push_back(origCornerPoint);
                 }
                 else
                 {

--- a/src/engine/Map.cxx
+++ b/src/engine/Map.cxx
@@ -462,6 +462,20 @@ void Map::highlightNode(const Point &isoCoordinates, const SpriteRGBColor &rgbCo
   }
 }
 
+std::string Map::getTileID(const Point &isoCoordinates, Layer layer)
+{
+  const size_t index = isoCoordinates.x * m_columns + isoCoordinates.y;
+  if (index < mapNodes.size())
+  {
+    MapNode *node = mapNodes[index].get();
+    if (node)
+    {
+      return node->getTileID(layer);
+    }
+  }
+  return "";
+}
+
 void Map::unHighlightNode(const Point &isoCoordinates)
 {
   const size_t index = isoCoordinates.x * m_columns + isoCoordinates.y;

--- a/src/engine/Map.hxx
+++ b/src/engine/Map.hxx
@@ -158,6 +158,12 @@ public:
   */
   std::vector<Point> getObjectCoords(const Point &isoCoordinates, const std::string &tileID);
 
+  /** \Brief get Tile ID of specific layer of specific iso coordinates
+  * @param isoCoordinates: Tile to inspect
+  * @param layer: layer to check.
+  */
+  std::string getTileID(const Point &isoCoordinates, Layer layer);
+
 private:
   int m_columns;
   int m_rows;


### PR DESCRIPTION
this fix is regarding buildings bigger than 1x1.
all tiles of already existed building is now highlighted instead of base corner tile.