### PR TITLE
Fix Tileselection

### DIFF
--- a/src/engine/Map.cxx
+++ b/src/engine/Map.cxx
@@ -413,8 +413,9 @@ bool Map::isClickWithinTile(const SDL_Point &screenCoordinates, int isoX, int is
     {
       // Calculate the position of the clicked pixel within the surface and "un-zoom" the position to match the un-adjusted surface
       const int pixelX =
-          static_cast<int>(std::round(static_cast<float>(screenCoordinates.x - spriteRect.x) / Camera::zoomLevel)) + clipRect.x;
-      const int pixelY = static_cast<int>(std::round(static_cast<float>(screenCoordinates.y - spriteRect.y) / Camera::zoomLevel));
+          static_cast<int>(std::round(static_cast<double>(screenCoordinates.x - spriteRect.x) / Camera::zoomLevel)) + clipRect.x;
+      const int pixelY =
+          static_cast<int>(std::round(static_cast<double>(screenCoordinates.y - spriteRect.y) / Camera::zoomLevel));
 
       // Check if the clicked Sprite is not transparent (we hit a point within the pixel)
       if (getColorOfPixelInSurface(ResourcesManager::instance().getTileSurface(
@@ -437,9 +438,9 @@ bool Map::isClickWithinTile(const SDL_Point &screenCoordinates, int isoX, int is
       // Calculate the position of the clicked pixel within the surface and "un-zoom" the position to match the un-adjusted surface
       // we need to offset the click coordinates by the clipping coordinates to check for the right sprite in the spritesheet.
       const int pixelX =
-          static_cast<int>(std::round(static_cast<float>(screenCoordinates.x - spriteRect.x) / Camera::zoomLevel)) + clipRect.x;
+          static_cast<int>(std::round(static_cast<double>(screenCoordinates.x - spriteRect.x) / Camera::zoomLevel)) + clipRect.x;
       const int pixelY =
-          static_cast<int>(std::round(static_cast<float>(screenCoordinates.y - spriteRect.y) / Camera::zoomLevel)) + clipRect.y;
+          static_cast<int>(std::round(static_cast<double>(screenCoordinates.y - spriteRect.y) / Camera::zoomLevel)) + clipRect.y;
       // Check if the clicked Sprite is not transparent (we hit a point within the pixel)
       if (getColorOfPixelInSurface(ResourcesManager::instance().getTileSurface(
                                        mapNodes[isoX * m_columns + isoY]->getMapNodeDataForLayer(Layer::TERRAIN).tileID),
@@ -462,9 +463,9 @@ bool Map::isClickWithinTile(const SDL_Point &screenCoordinates, int isoX, int is
       // Calculate the position of the clicked pixel within the surface and "un-zoom" the position to match the un-adjusted surface
       // we need to offset the click coordinates by the clipping coordinates to check for the right sprite in the spritesheet.
       const int pixelX =
-          static_cast<int>(std::round(static_cast<float>(screenCoordinates.x - spriteRect.x) / Camera::zoomLevel)) + clipRect.x;
+          static_cast<int>(std::round(static_cast<double>(screenCoordinates.x - spriteRect.x) / Camera::zoomLevel)) + clipRect.x;
       const int pixelY =
-          static_cast<int>(std::round(static_cast<float>(screenCoordinates.y - spriteRect.y) / Camera::zoomLevel)) + clipRect.y;
+          static_cast<int>(std::round(static_cast<double>(screenCoordinates.y - spriteRect.y) / Camera::zoomLevel)) + clipRect.y;
       // Check if the clicked Sprite is not transparent (we hit a point within the pixel)
       if (getColorOfPixelInSurface(ResourcesManager::instance().getTileSurface(
                                        mapNodes[isoX * m_columns + isoY]->getMapNodeDataForLayer(Layer::WATER).tileID),
@@ -486,9 +487,9 @@ bool Map::isClickWithinTile(const SDL_Point &screenCoordinates, int isoX, int is
       // Calculate the position of the clicked pixel within the surface and "un-zoom" the position to match the un-adjusted surface
       // we need to offset the click coordinates by the clipping coordinates to check for the right sprite in the spritesheet.
       const int pixelX =
-          static_cast<int>(std::round(static_cast<float>(screenCoordinates.x - spriteRect.x) / Camera::zoomLevel)) + clipRect.x;
+          static_cast<int>(std::round(static_cast<double>(screenCoordinates.x - spriteRect.x) / Camera::zoomLevel)) + clipRect.x;
       const int pixelY =
-          static_cast<int>(std::round(static_cast<float>(screenCoordinates.y - spriteRect.y) / Camera::zoomLevel)) + clipRect.y;
+          static_cast<int>(std::round(static_cast<double>(screenCoordinates.y - spriteRect.y) / Camera::zoomLevel)) + clipRect.y;
       // Check if the clicked Sprite is not transparent (we hit a point within the pixel)
       if (getColorOfPixelInSurface(ResourcesManager::instance().getTileSurface(
                                        mapNodes[isoX * m_columns + isoY]->getMapNodeDataForLayer(Layer::BLUEPRINT).tileID),
@@ -511,9 +512,9 @@ bool Map::isClickWithinTile(const SDL_Point &screenCoordinates, int isoX, int is
       // Calculate the position of the clicked pixel within the surface and "un-zoom" the position to match the un-adjusted surface
       // we need to offset the click coordinates by the clipping coordinates to check for the right sprite in the spritesheet.
       const int pixelX =
-          static_cast<int>(std::round(static_cast<float>(screenCoordinates.x - spriteRect.x) / Camera::zoomLevel)) + clipRect.x;
+          static_cast<int>(std::round(static_cast<double>(screenCoordinates.x - spriteRect.x) / Camera::zoomLevel)) + clipRect.x;
       const int pixelY =
-          static_cast<int>(std::round(static_cast<float>(screenCoordinates.y - spriteRect.y) / Camera::zoomLevel)) + clipRect.y;
+          static_cast<int>(std::round(static_cast<double>(screenCoordinates.y - spriteRect.y) / Camera::zoomLevel)) + clipRect.y;
       // Check if the clicked Sprite is not transparent (we hit a point within the pixel)
       if (getColorOfPixelInSurface(ResourcesManager::instance().getTileSurface(
                                        mapNodes[isoX * m_columns + isoY]->getMapNodeDataForLayer(Layer::UNDERGROUND).tileID),

--- a/src/engine/Map.cxx
+++ b/src/engine/Map.cxx
@@ -432,15 +432,16 @@ bool Map::isClickWithinTile(const SDL_Point &screenCoordinates, int isoX, int is
   {
     SDL_Rect spriteRect = mapNodes[isoX * m_columns + isoY]->getSprite()->getDestRect(Layer::TERRAIN);
     SDL_Rect clipRect = mapNodes[isoX * m_columns + isoY]->getSprite()->getClipRect(Layer::TERRAIN);
+    clipRect.h += 1; //HACK: We need to increase clipRect height by one to match all points in the drawRect. This is likely be caused by 
 
     if (SDL_PointInRect(&screenCoordinates, &spriteRect))
     {
       // Calculate the position of the clicked pixel within the surface and "un-zoom" the position to match the un-adjusted surface
       // we need to offset the click coordinates by the clipping coordinates to check for the right sprite in the spritesheet.
       const int pixelX =
-          static_cast<int>(std::round(static_cast<double>(screenCoordinates.x - spriteRect.x) / Camera::zoomLevel)) + clipRect.x;
+          static_cast<int>((screenCoordinates.x - spriteRect.x) / Camera::zoomLevel) + clipRect.x;
       const int pixelY =
-          static_cast<int>(std::round(static_cast<double>(screenCoordinates.y - spriteRect.y) / Camera::zoomLevel)) + clipRect.y;
+          static_cast<int>((screenCoordinates.y - spriteRect.y) / Camera::zoomLevel) + clipRect.y;
       // Check if the clicked Sprite is not transparent (we hit a point within the pixel)
       if (getColorOfPixelInSurface(ResourcesManager::instance().getTileSurface(
                                        mapNodes[isoX * m_columns + isoY]->getMapNodeDataForLayer(Layer::TERRAIN).tileID),

--- a/src/engine/Sprite.cxx
+++ b/src/engine/Sprite.cxx
@@ -69,9 +69,9 @@ void Sprite::refresh()
         if (m_SpriteData[currentLayer].clipRect.w != 0)
         {
           m_SpriteData[currentLayer].destRect.w =
-              static_cast<int>(std::round(static_cast<float>(m_SpriteData[currentLayer].clipRect.w) * m_currentZoomLevel));
+              static_cast<int>(std::round(static_cast<double>(m_SpriteData[currentLayer].clipRect.w) * m_currentZoomLevel));
           m_SpriteData[currentLayer].destRect.h =
-              static_cast<int>(std::round(static_cast<float>(m_SpriteData[currentLayer].clipRect.h) * m_currentZoomLevel));
+              static_cast<int>(std::round(static_cast<double>(m_SpriteData[currentLayer].clipRect.h) * m_currentZoomLevel));
         }
         else
         {
@@ -79,9 +79,9 @@ void Sprite::refresh()
                            &m_SpriteData[currentLayer].destRect.h);
 
           m_SpriteData[currentLayer].destRect.w =
-              static_cast<int>(std::round(static_cast<float>(m_SpriteData[currentLayer].clipRect.w) * m_currentZoomLevel));
+              static_cast<int>(std::round(static_cast<double>(m_SpriteData[currentLayer].clipRect.w) * m_currentZoomLevel));
           m_SpriteData[currentLayer].destRect.h =
-              static_cast<int>(std::round(static_cast<float>(m_SpriteData[currentLayer].clipRect.h) * m_currentZoomLevel));
+              static_cast<int>(std::round(static_cast<double>(m_SpriteData[currentLayer].clipRect.h) * m_currentZoomLevel));
         }
       }
     }

--- a/src/engine/Sprite.hxx
+++ b/src/engine/Sprite.hxx
@@ -59,7 +59,7 @@ private:
   SDL_Point m_screenCoordinates{0, 0};
 
   bool m_needsRefresh = false;
-  float m_currentZoomLevel = 0;
+  double m_currentZoomLevel = 0;
 
   std::vector<SpriteData> m_SpriteData;
 };

--- a/src/engine/basics/Camera.cxx
+++ b/src/engine/basics/Camera.cxx
@@ -6,14 +6,14 @@
 SDL_Point Camera::tileSize{32, 16};
 SDL_Point Camera::cameraOffset{0, 0};
 Point Camera::centerIsoCoordinates;
-float Camera::zoomLevel = 1.0F;
+double Camera::zoomLevel = 1;
 float Camera::m_pinchDistance = 0.0F;
 
 void Camera::increaseZoomLevel()
 {
-  if (zoomLevel < 4.0F)
+  if (zoomLevel < 4.0)
   {
-    zoomLevel += 0.5F;
+    zoomLevel += 0.5;
     centerScreenOnPoint(centerIsoCoordinates);
     if (Engine::instance().map != nullptr)
       Engine::instance().map->refresh();
@@ -22,9 +22,9 @@ void Camera::increaseZoomLevel()
 
 void Camera::decreaseZoomLevel()
 {
-  if (zoomLevel > 0.5F)
+  if (zoomLevel > 0.5)
   {
-    zoomLevel -= 0.5F;
+    zoomLevel -= 0.5;
     centerScreenOnPoint(centerIsoCoordinates);
     if (Engine::instance().map != nullptr)
       Engine::instance().map->refresh();
@@ -38,7 +38,7 @@ void Camera::setPinchDistance(float pinchDistance, int isoX, int isoY)
   if (m_pinchDistance > 0.25F)
   {
     m_pinchDistance = 0;
-    if (zoomLevel < 4.0F)
+    if (zoomLevel < 4.0)
     {
       centerScreenOnPoint({isoX, isoY, 0, 0});
     }
@@ -47,7 +47,7 @@ void Camera::setPinchDistance(float pinchDistance, int isoX, int isoY)
   else if (m_pinchDistance < -0.25F)
   {
     m_pinchDistance = 0;
-    if (zoomLevel > 0.5F)
+    if (zoomLevel > 0.5)
     {
       centerScreenOnPoint({isoX, isoY, 0, 0});
     }

--- a/src/engine/basics/Camera.hxx
+++ b/src/engine/basics/Camera.hxx
@@ -12,7 +12,7 @@ public:
   /// the offset of the camera.
   static SDL_Point cameraOffset;
   /// the zoom level of the camera.
-  static float zoomLevel;
+  static double zoomLevel;
 
   /** \brief Centers camera on given isometric coordinates
   * Centers the camera on the given isometric coordinates.

--- a/src/engine/basics/isoMath.cxx
+++ b/src/engine/basics/isoMath.cxx
@@ -23,9 +23,9 @@ SDL_Point convertIsoToScreenCoordinates(const Point &isoCoordinates, bool calcWi
   const int heightOffset = 24;
 
   int x = static_cast<int>(
-      std::round(static_cast<float>((isoCoordinates.x + isoCoordinates.y) * Camera::tileSize.x) * Camera::zoomLevel) / 2);
+      std::round(static_cast<double>((isoCoordinates.x + isoCoordinates.y) * Camera::tileSize.x) * Camera::zoomLevel) / 2);
   int y = static_cast<int>(
-      std::round(static_cast<float>((isoCoordinates.x - isoCoordinates.y) * Camera::tileSize.y) * Camera::zoomLevel) / 2);
+      std::round(static_cast<double>((isoCoordinates.x - isoCoordinates.y) * Camera::tileSize.y) * Camera::zoomLevel) / 2);
 
   if (!calcWithoutOffset)
   {
@@ -36,7 +36,7 @@ SDL_Point convertIsoToScreenCoordinates(const Point &isoCoordinates, bool calcWi
   if (isoCoordinates.height > 0)
   {
     y -= static_cast<int>(
-        std::round(static_cast<float>((Camera::tileSize.x - heightOffset) * isoCoordinates.height) * Camera::zoomLevel));
+        std::round(static_cast<double>((Camera::tileSize.x - heightOffset) * isoCoordinates.height) * Camera::zoomLevel));
   }
 
   return {x, y};


### PR DESCRIPTION
The clipRect (sourceRect) is smaller by one pixel than the destRect. I think this is related to rounding errors.

In this PR, i made it 1px taller and now the tile selection jumpyness is gone