### PR TITLE
Fix demolish tool

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,40 +1,41 @@
 ===Cytopia Changelog:===
 
-v0.2.1
-- [UI]
-- Opening the settings menu closes main menu (was left open in the background)
-- UI can be hidden for screenshots when pressing the 'h' key on the keyboard
-- Fixed UI text alignment in ComboBoxes.
-- Add subcategory buttons to debug menu to show more buildings
-- Center Ui group elements if they would otherwise exceed screen estate
-- Right click will no longer trigger an UI interaction
-- Screen resolution can now be changed ingame
-- Ui Menu position can now be changed ingame
-- [Tiles]
-- Fixed a bug in autotiling
-- Added new trees and other biome related graphics and prepare biome json information for further terraingen improvements
-- Changed how road spritesheets are handled. Now the tiles are used from a single spritesheets instead of having "default" tiles in an extra spritesheet
-- Added a "tileType" property to define certain behaviour, like "autotile" instead of handling this via tileCategory
-- Allow to place tiles over certain items, like trees.
+Here's my revised version:
+===Cytopia v0.2.1 Changelog:===
+General:
+- Fixed a bug where the game would crash when the terrain was elevated and an in-between tile was created.
+- Fixed a few bugs in the line placement mode.
+- Added a preview for buildings that are bigger than 1x1.
+- When placing buildings bigger than 1x1, the placement is now correctly checked.
+- Added support for diagonal roads.
+- Pressing ESC now stops the tile-placement mode.
+- Added shorelines.
+Gameplay:
+- Added three different selection modes; single, rectangular, and line. The mode is chosen automatically for the right tiles.
+- Added RCI zone tiles by RockFort.
+- Added a blueprint layer mode. When placing water pipes, the game switches to this blueprint mode automatically.
+- Roads of different types now won't autotile to each other.
+- Holding down the SHIFT key will use straight line placement mode instead of the diagonal line placement mode.
+- Holding down the CTRL key will place straight road corners instead of diagonal ones.
+- Added De-Zone tool - Hold down SHIFT key while in demolish mode.
+- Added a tool to remove ground decoration only. - Hold down CTRL key while in demolish mode. 
+- Added panning for both WASD and the arrow keys.
+Tiles:
+- Fixed a bug in autotiling.
+- Added new trees and other biome-related graphics and prepared biome JSON information for further terrain generation improvements.
+- Changed how road spritesheets are handled. Now the tiles are used from a single spritesheet instead of having "default" tiles in an extra spritesheet.
+- Added a "tileType" property to define certain behaviors, like "autotile" instead of handling this via tileCategory.
+- Items can now be placed over certain items, like trees, without deleting them first.
 - Added a property to allow placement of tiles on water
-- [Gameplay]
-- Added 3 different selection Modes. Single, Rectangular and Line. The mode is chosen automitcally for the right tiles
-- Added RCI Zone tiles
-- Added Blueprint layer mode. When placing water pipes, the game switches to blueprint mode automatically
-- Roads of different type now won't autotile to each other
-- Hold down SHIFT key to use straight line placement mode instead of diagonal line placement mode
-- Hold down CTRL key to place straight road corners instead of diagonal ones
-- added panning for both WASD and arrow keys.
-- [General]
-- Fixed a bug where the game would crash when terrain was elevated and an in-between tile was created
-- Fixed a few bugs in Line placement mode
-- Preview for Buildings that are bigger than 1x1
-- When placing buildings bigger than 1x1, placement is now correctly checked
-- Added support for diagonal Roads
-- Tiles occupied by buildings larger than 1x1 are now correctly detected when placing new buildings
-- Now pressing ESC stops tile-placement mode
-- Added shorelines
-- Added more Bugs to fix later
+UI:
+- Opening the settings menu now hides the category UI.
+- The UI can be hidden for screenshots by pressing the H key.
+- Fixed the UI text alignment in ComboBoxes.
+- Added subcategory buttons to the debug menu to show more buildings.
+- Centered UI items if they would normally go off the screen.
+- Right-click will no longer trigger a UI interaction.
+- Screen resolution can now be changed in-game.
+- The UI menu position can now be changed in-game.
 
 v0.2
 - A new 32-bit version of Cytopia has been made for users with older machines

--- a/src/engine/EventManager.cxx
+++ b/src/engine/EventManager.cxx
@@ -465,8 +465,9 @@ void EventManager::checkEvents(SDL_Event &event, Engine &engine)
       // gather all nodes the objects that'll be placed is going to occupy.
       std::vector targetObjectNodes = engine.map->getObjectCoords(mouseIsoCoords, tileToPlace);
 
-      if (event.button.button == SDL_BUTTON_LEFT && m_placementAllowed)
+      if (event.button.button == SDL_BUTTON_LEFT)
       {
+
         if (m_tileInfoMode)
         {
           engine.map->getNodeInformation({mouseIsoCoords.x, mouseIsoCoords.y, 0, 0});
@@ -479,7 +480,7 @@ void EventManager::checkEvents(SDL_Event &event, Engine &engine)
         {
           engine.decreaseHeight(mouseIsoCoords);
         }
-        else if (!tileToPlace.empty())
+        else if (!tileToPlace.empty() && m_placementAllowed)
         {
           // if targetObject.size > 1 it is a tile bigger than 1x1
           if (targetObjectNodes.size() > 1 && isPointWithinMapBoundaries(targetObjectNodes))
@@ -492,13 +493,10 @@ void EventManager::checkEvents(SDL_Event &event, Engine &engine)
             engine.setTileIDOfNode(m_nodesToPlace.begin(), m_nodesToPlace.end(), tileToPlace, true);
           }
         }
+
         else if (demolishMode)
         {
-          engine.map->demolishNode(mouseIsoCoords, true);
-        }
-        else
-        {
-          LOG(LOG_INFO) << "CLICKED - Iso Coords: " << mouseIsoCoords.x << ", " << mouseIsoCoords.y;
+          engine.map->demolishNode(m_nodesToHighlight, true);
         }
       }
       // when we're done, reset highlighting

--- a/src/engine/EventManager.cxx
+++ b/src/engine/EventManager.cxx
@@ -66,9 +66,11 @@ void EventManager::checkEvents(SDL_Event &event, Engine &engine)
       case SDLK_0:
         break;
       case SDLK_LCTRL:
+        GameStates::instance().demolishMode = DemolishMode::GROUND_DECORATION;
         GameStates::instance().rectangularRoads = true;
         break;
       case SDLK_LSHIFT:
+        GameStates::instance().demolishMode = DemolishMode::DE_ZONE;
         if (GameStates::instance().placementMode == PlacementMode::LINE)
         {
           GameStates::instance().placementMode = PlacementMode::STRAIGHT_LINE;
@@ -168,9 +170,11 @@ void EventManager::checkEvents(SDL_Event &event, Engine &engine)
       switch (event.key.keysym.sym)
       {
       case SDLK_LCTRL:
+        GameStates::instance().demolishMode = DemolishMode::DEFAULT;
         GameStates::instance().rectangularRoads = false;
         break;
       case SDLK_LSHIFT:
+        GameStates::instance().demolishMode = DemolishMode::DEFAULT;
         if (GameStates::instance().placementMode == PlacementMode::STRAIGHT_LINE)
         {
           GameStates::instance().placementMode = PlacementMode::LINE;

--- a/src/engine/GameObjects/MapNode.cxx
+++ b/src/engine/GameObjects/MapNode.cxx
@@ -357,17 +357,17 @@ void MapNode::setMapNodeData(std::vector<MapNodeData> &&mapNodeData, const Point
   }
 }
 
-void MapNode::demolishNode(Layer layer)
+void MapNode::demolishNode(Layer demolishLayer)
 {
   // allow to delete a single layer only
   std::vector<Layer> layersToDemolish;
-  if (layer == Layer::NONE)
+  if (demolishLayer == Layer::NONE)
   {
     layersToDemolish = {Layer::BUILDINGS, Layer::UNDERGROUND, Layer::GROUND_DECORATION};
   }
   else
   {
-    layersToDemolish.push_back(layer);
+    layersToDemolish.push_back(demolishLayer);
   }
 
   for (auto &layer : layersToDemolish)

--- a/src/engine/GameObjects/MapNode.cxx
+++ b/src/engine/GameObjects/MapNode.cxx
@@ -357,19 +357,33 @@ void MapNode::setMapNodeData(std::vector<MapNodeData> &&mapNodeData, const Point
   }
 }
 
-void MapNode::demolishNode()
+void MapNode::demolishNode(Layer layer)
 {
-  Layer myLayers[] = {Layer::BUILDINGS, Layer::UNDERGROUND, Layer::GROUND_DECORATION};
-  for (auto &layer : myLayers)
+  // allow to delete a single layer only
+  std::vector<Layer> layersToDemolish;
+  if (layer == Layer::NONE)
+  {
+    layersToDemolish = {Layer::BUILDINGS, Layer::UNDERGROUND, Layer::GROUND_DECORATION};
+  }
+  else
+  {
+    layersToDemolish.push_back(layer);
+  }
+
+  for (auto &layer : layersToDemolish)
   {
     if (MapLayers::isLayerActive(layer))
     {
+      if (m_mapNodeData[layer].tileData && m_mapNodeData[layer].tileData->tileType == +TileType::ZONE)
+      {
+        continue;
+      }
+
       m_mapNodeData[layer].tileData = nullptr;
       m_mapNodeData[layer].tileID = "";
       m_mapNodeData[layer].origCornerPoint = this->getCoordinates();
       m_sprite->clearSprite(layer);
       updateTexture();
-      break;
     }
   }
 }

--- a/src/engine/GameObjects/MapNode.cxx
+++ b/src/engine/GameObjects/MapNode.cxx
@@ -372,9 +372,14 @@ void MapNode::demolishNode(Layer layer)
 
   for (auto &layer : layersToDemolish)
   {
-    if (MapLayers::isLayerActive(layer))
+    if (MapLayers::isLayerActive(layer) && m_mapNodeData[layer].tileData)
     {
-      if (m_mapNodeData[layer].tileData && m_mapNodeData[layer].tileData->tileType == +TileType::ZONE)
+      if ((GameStates::instance().demolishMode == DemolishMode::DEFAULT &&
+           m_mapNodeData[layer].tileData->tileType == +TileType::ZONE) ||
+          (GameStates::instance().demolishMode == DemolishMode::DE_ZONE &&
+           m_mapNodeData[layer].tileData->tileType != +TileType::ZONE) ||
+          (GameStates::instance().demolishMode == DemolishMode::GROUND_DECORATION &&
+           m_mapNodeData[layer].tileData->tileType != +TileType::GROUNDDECORATION))
       {
         continue;
       }

--- a/src/engine/GameObjects/MapNode.hxx
+++ b/src/engine/GameObjects/MapNode.hxx
@@ -104,7 +104,15 @@ public:
     */
   bool isPlacableOnSlope(const std::string &tileID) const;
 
-  void demolishNode();
+  /**
+ * @brief Demolish a node
+ * Removes all tiles on a node. This effects all layers where something to demolish is placed. (BUILDINGS, GROUND_DECORATION, UNDERGROUND) per default, but can be restricted to a single Layer. 
+ * @param isoCoordinates all coordinates that should be demolished
+ * @param updateNeighboringTiles wether the adjecent tiles should be updated. (only relevant for autotiling)
+ * @param layer restrict demolish to a single layer 
+ * @see MapNode#demolishNode
+ */
+  void demolishNode(Layer layer = Layer::NONE);
 
   void setTileID(const std::string &tileType, const Point &origPoint);
 

--- a/src/engine/Map.cxx
+++ b/src/engine/Map.cxx
@@ -402,8 +402,9 @@ void Map::demolishNode(const std::vector<Point> &isoCoordinates, bool updateNeig
     MapNode *node = mapNodes[isoCoord.x * m_columns + isoCoord.y].get();
     if (isPointWithinMapBoundaries(isoCoord))
     {
-      // Check if there's something on the BUILDINGS layer before checking origCornerPoint
-      if (node->getMapNodeDataForLayer(Layer::BUILDINGS).tileData)
+      // Check for multinode buildings first. Those are on the buildings layer, even if we want to demolish another layer than Buildings.
+      // In case we add more Layers that support Multinode, add a for loop here
+      if (node->getMapNodeDataForLayer(Layer::BUILDINGS).tileData && isNodeMultiObject(isoCoord))
       {
         const Point origCornerPoint = mapNodes[isoCoord.x * m_columns + isoCoord.y]->getOrigCornerPoint(Layer::BUILDINGS);
         const size_t origIndex = origCornerPoint.x * m_columns + origCornerPoint.y;
@@ -423,7 +424,7 @@ void Map::demolishNode(const std::vector<Point> &isoCoordinates, bool updateNeig
           }
         }
       }
-      // add the points to the vector if they're not in it (if they're a multiobject there'd be duplicates)
+      // make sure to add the points from the parameter to the vector if they're not in it (if they're a multiobject there'd be duplicates)
       if (std::find(nodesToDemolish.begin(), nodesToDemolish.end(),
                     mapNodes[isoCoord.x * m_columns + isoCoord.y]->getCoordinates()) == nodesToDemolish.end())
       {
@@ -611,9 +612,9 @@ Map *Map::loadMapFromFile(const std::string &fileName)
   return map;
 }
 
-  bool Map::isNodeMultiObject(const Point &isoCoordinates, Layer layer)
+bool Map::isNodeMultiObject(const Point &isoCoordinates, Layer layer)
 {
-    if (isPointWithinMapBoundaries(isoCoordinates) && mapNodes[isoCoordinates.x * m_columns + isoCoordinates.y])
+  if (isPointWithinMapBoundaries(isoCoordinates) && mapNodes[isoCoordinates.x * m_columns + isoCoordinates.y])
   {
     MapNode *mapNode = mapNodes[isoCoordinates.x * m_columns + isoCoordinates.y].get();
     return (mapNode->getTileData(layer)->RequiredTiles.height > 1 && mapNode->getTileData(layer)->RequiredTiles.width > 1);

--- a/src/engine/Map.cxx
+++ b/src/engine/Map.cxx
@@ -394,7 +394,7 @@ Point Map::findNodeInMap(const SDL_Point &screenCoordinates) const
   return foundCoordinates;
 }
 
-void Map::demolishNode(const std::vector<Point> &isoCoordinates, bool updateNeighboringTiles)
+void Map::demolishNode(const std::vector<Point> &isoCoordinates, bool updateNeighboringTiles, Layer layer)
 {
   std::vector<Point> nodesToDemolish;
   for (auto &isoCoord : isoCoordinates)
@@ -434,7 +434,7 @@ void Map::demolishNode(const std::vector<Point> &isoCoordinates, bool updateNeig
 
   for (auto &coords : nodesToDemolish)
   {
-    mapNodes[coords.x * m_columns + coords.y]->demolishNode();
+    mapNodes[coords.x * m_columns + coords.y]->demolishNode(layer);
     if (updateNeighboringTiles)
     {
       updateNeighborsOfNode({coords.x, coords.y});

--- a/src/engine/Map.cxx
+++ b/src/engine/Map.cxx
@@ -79,7 +79,7 @@ void Map::increaseHeight(const Point &isoCoordinates)
 
   if (height < Settings::instance().maxElevationHeight)
   {
-    demolishNode(isoCoordinates);
+    demolishNode(std::vector<Point>{isoCoordinates});
     mapNodes[isoCoordinates.x * m_columns + isoCoordinates.y]->increaseHeight();
     updateNeighborsOfNode(mapNodes[isoCoordinates.x * m_columns + isoCoordinates.y]->getCoordinates());
     mapNodes[isoCoordinates.x * m_columns + isoCoordinates.y]->getSprite()->refresh();
@@ -92,7 +92,7 @@ void Map::decreaseHeight(const Point &isoCoordinates)
 
   if (height > 0)
   {
-    demolishNode(isoCoordinates);
+    demolishNode(std::vector<Point>{isoCoordinates});
     mapNodes[isoCoordinates.x * m_columns + isoCoordinates.y]->decreaseHeight();
     updateNeighborsOfNode(mapNodes[isoCoordinates.x * m_columns + isoCoordinates.y]->getCoordinates());
     mapNodes[isoCoordinates.x * m_columns + isoCoordinates.y]->getSprite()->refresh();
@@ -117,7 +117,7 @@ void Map::updateNeighborsOfNode(const Point &isoCoordinates)
       // if the elevation bitmask changes (-> a new texture is drawn), demolish the tile
       if (elevationBitmask != it->getElevationBitmask())
       {
-        demolishNode(it->getCoordinates());
+        demolishNode(std::vector<Point>{it->getCoordinates()});
       }
 
       // set elevation and tile bitmask for each neighbor
@@ -394,34 +394,52 @@ Point Map::findNodeInMap(const SDL_Point &screenCoordinates) const
   return foundCoordinates;
 }
 
-void Map::demolishNode(const Point &isoCoordinates, bool updateNeighboringTiles)
+void Map::demolishNode(const std::vector<Point> &isoCoordinates, bool updateNeighboringTiles)
 {
-  const size_t index = isoCoordinates.x * m_columns + isoCoordinates.y;
-  if (index < mapNodes.size())
+  std::vector<Point> nodesToDemolish;
+  for (auto &isoCoord : isoCoordinates)
   {
-    const Layer layer = Layer::BUILDINGS;
-    const Point origCornerPoint = mapNodes[isoCoordinates.x * m_columns + isoCoordinates.y]->getOrigCornerPoint(layer);
-    const size_t origIndex = origCornerPoint.x * m_columns + origCornerPoint.y;
-
-    if (origIndex < mapNodes.size() && mapNodes[origIndex])
+    MapNode *node = mapNodes[isoCoord.x * m_columns + isoCoord.y].get();
+    if (isPointWithinMapBoundaries(isoCoord))
     {
-      const std::string &tileID = mapNodes[origIndex]->getTileID(layer);
-      std::vector<Point> objectCoordinates = getObjectCoords(origCornerPoint, tileID);
-
-      for (auto coords : objectCoordinates)
+      // Check if there's something on the BUILDINGS layer before checking origCornerPoint
+      if (node->getMapNodeDataForLayer(Layer::BUILDINGS).tileData)
       {
-        mapNodes[coords.x * m_columns + coords.y]->demolishNode();
+        const Point origCornerPoint = mapNodes[isoCoord.x * m_columns + isoCoord.y]->getOrigCornerPoint(Layer::BUILDINGS);
+        const size_t origIndex = origCornerPoint.x * m_columns + origCornerPoint.y;
+
+        if (origIndex < mapNodes.size() && mapNodes[origIndex])
+        {
+          const std::string &tileID = mapNodes[origIndex]->getTileID(Layer::BUILDINGS);
+          std::vector<Point> objectCoordinates = getObjectCoords(origCornerPoint, tileID);
+
+          for (auto coords : objectCoordinates)
+          {
+            if (std::find(nodesToDemolish.begin(), nodesToDemolish.end(),
+                          mapNodes[coords.x * m_columns + coords.y]->getCoordinates()) == nodesToDemolish.end())
+            {
+              nodesToDemolish.push_back(mapNodes[coords.x * m_columns + coords.y]->getCoordinates());
+            }
+          }
+        }
+      }
+      // add the points to the vector if they're not in it (if they're a multiobject there'd be duplicates)
+      if (std::find(nodesToDemolish.begin(), nodesToDemolish.end(),
+                    mapNodes[isoCoord.x * m_columns + isoCoord.y]->getCoordinates()) == nodesToDemolish.end())
+      {
+        nodesToDemolish.push_back(mapNodes[isoCoord.x * m_columns + isoCoord.y]->getCoordinates());
       }
     }
-    else
-    {
-      mapNodes[isoCoordinates.x * m_columns + isoCoordinates.y]->demolishNode();
-    }
-    // TODO: Play soundeffect here
+  }
+
+  for (auto &coords : nodesToDemolish)
+  {
+    mapNodes[coords.x * m_columns + coords.y]->demolishNode();
     if (updateNeighboringTiles)
     {
-      updateNeighborsOfNode({isoCoordinates.x, isoCoordinates.y});
+      updateNeighborsOfNode({coords.x, coords.y});
     }
+    // TODO: Play soundeffect here
   }
 }
 

--- a/src/engine/Map.cxx
+++ b/src/engine/Map.cxx
@@ -610,3 +610,13 @@ Map *Map::loadMapFromFile(const std::string &fileName)
 
   return map;
 }
+
+  bool Map::isNodeMultiObject(const Point &isoCoordinates, Layer layer)
+{
+    if (isPointWithinMapBoundaries(isoCoordinates) && mapNodes[isoCoordinates.x * m_columns + isoCoordinates.y])
+  {
+    MapNode *mapNode = mapNodes[isoCoordinates.x * m_columns + isoCoordinates.y].get();
+    return (mapNode->getTileData(layer)->RequiredTiles.height > 1 && mapNode->getTileData(layer)->RequiredTiles.width > 1);
+  }
+  return false;
+}

--- a/src/engine/Map.cxx
+++ b/src/engine/Map.cxx
@@ -404,6 +404,7 @@ void Map::demolishNode(const std::vector<Point> &isoCoordinates, bool updateNeig
     {
       // Check for multinode buildings first. Those are on the buildings layer, even if we want to demolish another layer than Buildings.
       // In case we add more Layers that support Multinode, add a for loop here
+      // If demolishNode is called for layer GROUNDECORATION, we'll still need to gather all nodes from the multinode building to delete the decoration under the entire building
       if (node->getMapNodeDataForLayer(Layer::BUILDINGS).tileData && isNodeMultiObject(isoCoord))
       {
         const Point origCornerPoint = mapNodes[isoCoord.x * m_columns + isoCoord.y]->getOrigCornerPoint(Layer::BUILDINGS);

--- a/src/engine/Map.hxx
+++ b/src/engine/Map.hxx
@@ -92,7 +92,7 @@ public:
       for (auto it = begin; it != end; ++it)
       {
         bool shouldRender = !(!isMultiObjects && it != begin);
-        demolishNode(*it);
+        demolishNode(std::vector<Point>{*it});
         mapNodes[it->x * m_columns + it->y]->setRenderFlag(TileManager::instance().getTileLayer(tileID), shouldRender);
         mapNodes[it->x * m_columns + it->y]->setTileID(tileID, isMultiObjects ? *it : *begin);
         updateNeighborsOfNode(*it);
@@ -107,7 +107,7 @@ public:
  * @param updateNeighboringTiles 
  * @see MapNode#demolishNode
  */
-  void demolishNode(const Point &isoCoordinates, bool updateNeighboringTiles = false);
+  void demolishNode(const std::vector<Point> &isoCoordinates, bool updateNeighboringTiles = false);
 
   /**
    * @brief Refresh all the map tile textures

--- a/src/engine/Map.hxx
+++ b/src/engine/Map.hxx
@@ -92,7 +92,7 @@ public:
       for (auto it = begin; it != end; ++it)
       {
         bool shouldRender = !(!isMultiObjects && it != begin);
-        demolishNode(std::vector<Point>{*it});
+        demolishNode(std::vector<Point>{*it}, 0, Layer::BUILDINGS);
         mapNodes[it->x * m_columns + it->y]->setRenderFlag(TileManager::instance().getTileLayer(tileID), shouldRender);
         mapNodes[it->x * m_columns + it->y]->setTileID(tileID, isMultiObjects ? *it : *begin);
         updateNeighborsOfNode(*it);
@@ -102,12 +102,13 @@ public:
 
   /**
  * @brief Demolish a node
- * Invokes the tiles demolish function
- * @param isoCoordinates 
- * @param updateNeighboringTiles 
+ * This function gathers all tiles that should be demolished and invokes the nodes demolish function. When a building bigger than 1x1 is selected, all it's coordinates are added to the demolishing points.
+ * @param isoCoordinates all coordinates that should be demolished
+ * @param updateNeighboringTiles wether the adjecent tiles should be updated. (only relevant for autotiling)
+ * @param layer restrict demolish to a single layer 
  * @see MapNode#demolishNode
  */
-  void demolishNode(const std::vector<Point> &isoCoordinates, bool updateNeighboringTiles = false);
+  void demolishNode(const std::vector<Point> &isoCoordinates, bool updateNeighboringTiles = false, Layer layer = Layer::NONE);
 
   /**
    * @brief Refresh all the map tile textures

--- a/src/engine/Map.hxx
+++ b/src/engine/Map.hxx
@@ -122,6 +122,13 @@ public:
    */
   Point getNodeOrigCornerPoint(const Point &isoCoordinates, Layer layer = Layer::NONE);
 
+  /**
+ * @brief whether a node is a multiobject or not (bigger than 1x1 building)
+ * @param isoCoordinates Tile to inspect
+ * @param layer Which layer to inspect (default BUILDINGS)
+ */
+  bool isNodeMultiObject(const Point &isoCoordinates, Layer layer = Layer::BUILDINGS);
+
   /** \Brief Save Map to file
   * Serializes the Map class to json and writes the data to a file.
   * @param fileName The file the map should be written to

--- a/src/engine/basics/GameStates.hxx
+++ b/src/engine/basics/GameStates.hxx
@@ -15,6 +15,7 @@ struct GameStatesData
   bool rectangularRoads = false; /// place rectangular road tiles instead of diagonal tils
   LayerEditMode layerEditMode = LayerEditMode::TERRAIN; /// Specifies the Layer Editmode. Editing Terrain or Blueprint (water pipes, subway,..) 
   PlacementMode placementMode = PlacementMode::LINE; /// Specifies the placement mode when holding down the mouse - single, line, ...
+  DemolishMode demolishMode = DemolishMode::DEFAULT;
 };
 
 class GameStates : public GameStatesData, public Singleton<GameStates>

--- a/src/engine/common/enums.hxx
+++ b/src/engine/common/enums.hxx
@@ -46,4 +46,11 @@ enum class PlacementMode
   RECTANGLE      /// draw a rectangle between start and end point
 };
 
+enum class DemolishMode
+{
+  DEFAULT,          /// Demolish everything, but not
+  DE_ZONE,          /// Remove only zones
+  GROUND_DECORATION /// Remove only ground decoration
+};
+
 #endif


### PR DESCRIPTION
- [x] Demolish tool should use a vector instead of a single point to allow demolishing of a rectangular zone
- [x] Placing bigger than 1x1 buildings demolish all occupied nodes. This will also remove ground decoration. Add a new parameter layer to allow demolishing of only one layer for this usecase
- [x] Add a De-zone tool, that will only delete zones (Shift key)
- [x] Add a tool to remove ground decoration only. (CTRL key)


![YGDvgqHrag](https://user-images.githubusercontent.com/7029836/78508099-9bb5e900-7784-11ea-9d91-eb75d9a8997d.gif)
