### PR TITLE
Make Vulkan dependency optional, fix travis-ci, and fix tool scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,15 +32,10 @@ matrix:
             - ninja-build
             - doxygen
             - graphviz
-            - libsdl2-dev
-            - libsdl2-image-dev
-            - libsdl2-mixer-dev
-            - libsdl2-ttf-dev
-            - libnoise-dev
-            - libopenal-dev
+            - gcc-8
 
       before_script:
-        - cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE=ON -DUSE_PACKAGE_MANAGER=OFF -DENABLE_ANGELSCRIPT=OFF -DENABLE_MOFILEREADER=OFF .
+        - cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE=ON -DENABLE_ANGELSCRIPT=OFF -DENABLE_MOFILEREADER=OFF .
 
       script:
         - >

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,13 +13,11 @@ option(ENABLE_AUDIO "Enable Audio" ON)
 option(ENABLE_MICROPROFILE "Enable microprofile" OFF)
 option(ENABLE_ANGELSCRIPT "Enable AngelScript" ON)
 option(ENABLE_MOFILEREADER "Enable MofileReader" ON)
+option(ENABLE_VULKAN "Enable Vulkan" OFF)
 
 # Comment-out uneeded libs
 if (NOT ENABLE_AUDIO)
     set(_CC_SDL2_MIXER "# ")
-endif ()
-
-if (NOT ENABLE_AUDIO)
     set(_CC_OPENAL_SOFT "# ")
 endif ()
 
@@ -33,6 +31,10 @@ endif ()
 
 if (NOT ENABLE_MOFILEREADER)
     set(_CC_MOFILEREADER "# ")
+endif ()
+
+if (NOT ENABLE_VULKAN)
+  set(_CC_VULKAN "# ")
 endif ()
 
 if (WIN32)
@@ -103,7 +105,6 @@ if (USE_PACKAGE_MANAGER)
             CONAN_PKG::sdl2_ttf
             CONAN_PKG::libnoise
             CONAN_PKG::zlib
-            CONAN_PKG::vulkan-sdk
             )
 
     if (ENABLE_AUDIO)
@@ -122,6 +123,10 @@ if (USE_PACKAGE_MANAGER)
         list(APPEND _link_libraries CONAN_PKG::MofileReader)
     endif ()
 
+    if (ENABLE_VULKAN)
+        list(APPEND _link_libraries CONAN_PKG::vulkan-sdk)
+    endif()
+
     if (BUILD_TEST)
         list(APPEND _link_libraries CONAN_PKG::Catch2)
     endif ()
@@ -133,7 +138,6 @@ else (USE_PACKAGE_MANAGER)
     pkg_check_modules(SDL2_image REQUIRED SDL2_image)
     pkg_check_modules(SDL2_ttf REQUIRED SDL2_ttf)
     pkg_check_modules(ZLIB REQUIRED zlib)
-    pkg_check_modules(VULKAN REQUIRED vulkan)
 
     if (ENABLE_AUDIO)
         pkg_check_modules(SDL2_mixer REQUIRED SDL2_mixer)
@@ -142,6 +146,10 @@ else (USE_PACKAGE_MANAGER)
     if (ENABLE_AUDIO)
         pkg_check_modules(openal REQUIRED openal)
     endif ()
+    
+    if (ENABLE_VULKAN)
+        pkg_check_modules(VULKAN REQUIRED vulkan)
+    endif()
 
     find_package(LIBNOISE REQUIRED)
 
@@ -162,7 +170,6 @@ else (USE_PACKAGE_MANAGER)
             ${SDL2_image_INCLUDE_DIRS}
             ${SDL2_ttf_INCLUDE_DIRS}
             ${ZLIB_INCLUDEDIR}
-            ${VULKAN_INCLUDEDIR}
             )
     list(APPEND _link_libraries
             ${SDL2_LIBRARIES}
@@ -170,7 +177,6 @@ else (USE_PACKAGE_MANAGER)
             ${SDL2_ttf_LIBRARIES}
             LIBNOISE::LIBNOISE_LIBRARIES
             ${ZLIB_LIBRARIES}
-            ${VULKAN_LIBRARIES}
             )
 
     if (ENABLE_AUDIO)
@@ -185,6 +191,11 @@ else (USE_PACKAGE_MANAGER)
     if (ENABLE_ANGELSCRIPT)
         list(APPEND _link_libraries ${AngelScript_LIBRARY})
     endif ()
+    
+    if (ENABLE_VULKAN)
+        list(APPEND _link_libraries ${VULKAN_LIBRARIES})
+        list(APPEND _include_directories ${VULKAN_INCLUDEDIR})
+    endif()
 
     if (BUILD_TEST)
         list(APPEND _include_directories ${CATCH2_INCLUDEDIR})

--- a/conanfile-win.txt.in
+++ b/conanfile-win.txt.in
@@ -16,6 +16,7 @@ OpenSSL/1.1.1c@conan/stable
 @_CC_CATCH2@Catch2/2.9.2@catchorg/stable
 @_CC_OPENAL_SOFT@openal/1.19.0@bincrafters/stable
 zlib/1.2.11
+@_CC_VULKAN@vulkan-sdk/1.1.126@cytopia/stable
 
 [options]
 sdl2:iconv=False

--- a/conanfile.txt.in
+++ b/conanfile.txt.in
@@ -16,7 +16,7 @@ OpenSSL/1.1.1c@conan/stable
 @_CC_CATCH2@Catch2/2.9.2@catchorg/stable
 @_CC_OPENAL_SOFT@openal/1.19.0@bincrafters/stable
 zlib/1.2.11
-vulkan-sdk/1.1.126@cytopia/stable
+@_CC_VULKAN@vulkan-sdk/1.1.126@cytopia/stable
 
 [options]
 sdl2_mixer:flac=False

--- a/tools/format-files.sh
+++ b/tools/format-files.sh
@@ -5,4 +5,6 @@ if ! [ -x "$(command -v clang-format)" ]; then
   exit
 fi
 
-find .. -regex '.*\.\(hxx\|cxx\)' -not -path '*/external/*' -exec clang-format -style=file -i {} \;
+BASE_DIRECTORY=$(dirname "$0")
+
+find "${BASE_DIRECTORY}/../src" -regex '.*\.\(hxx\|cxx\)' -not -path '*/external/*' -exec clang-format -style=file -i {} \;

--- a/tools/format-json.js
+++ b/tools/format-json.js
@@ -2,12 +2,12 @@
 const fs = require("fs");
 
 const fileList = [
-    "../data/resources/settings.json",
-    "../data/resources/data/AudioConfig.json",
-    "../data/resources/data/TerrainGen.json",
-    "../data/resources/data/TileData.json",
-    "../data/resources/data/UIData.json",
-    "../data/resources/data/UILayout.json"
+    `${__dirname}/data/resources/settings.json`,
+    `${__dirname}/data/resources/data/AudioConfig.json`,
+    `${__dirname}/data/resources/data/TerrainGen.json`,
+    `${__dirname}/data/resources/data/TileData.json`,
+    `${__dirname}/data/resources/data/UIData.json`,
+    `${__dirname}/data/resources/data/UILayout.json`
 ];
 
 function formatFile(file, index) {

--- a/tools/format-json.js
+++ b/tools/format-json.js
@@ -2,12 +2,12 @@
 const fs = require("fs");
 
 const fileList = [
-    `${__dirname}/data/resources/settings.json`,
-    `${__dirname}/data/resources/data/AudioConfig.json`,
-    `${__dirname}/data/resources/data/TerrainGen.json`,
-    `${__dirname}/data/resources/data/TileData.json`,
-    `${__dirname}/data/resources/data/UIData.json`,
-    `${__dirname}/data/resources/data/UILayout.json`
+    `${__dirname}/../data/resources/settings.json`,
+    `${__dirname}/../data/resources/data/AudioConfig.json`,
+    `${__dirname}/../data/resources/data/TerrainGen.json`,
+    `${__dirname}/../data/resources/data/TileData.json`,
+    `${__dirname}/../data/resources/data/UIData.json`,
+    `${__dirname}/../data/resources/data/UILayout.json`
 ];
 
 function formatFile(file, index) {


### PR DESCRIPTION
+ This makes Vulkan optional and disabled by default.
+ This makes our travis-ci GCC build use conan
+ This makes our tool scripts able to be ran from anywhere (before, we would need to be in the root directory of the project)