### PR TITLE
Optimize findNodeInMap function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ option(ENABLE_AUDIO "Enable Audio" ON)
 option(ENABLE_MICROPROFILE "Enable microprofile" OFF)
 option(ENABLE_ANGELSCRIPT "Enable AngelScript" ON)
 option(ENABLE_MOFILEREADER "Enable MofileReader" ON)
+option(ENABLE_DEBUG "Enable Debug (asserts and logs)" OFF)
 
 # Comment-out uneeded libs
 if (NOT ENABLE_AUDIO)
@@ -44,6 +45,11 @@ endif ()
 set(_include_directories "${CMAKE_CURRENT_SOURCE_DIR}/external/header_only")
 set(_compile_definitions "")
 set(_link_libraries "")
+
+if ( ENABLE_DEBUG OR CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+  set(_CC_MOFILEREADER "# ")
+  list(APPEND _compile_definitions DEBUG)
+endif ()
 
 # create the cmake project
 project(
@@ -186,12 +192,6 @@ else (USE_PACKAGE_MANAGER)
     endif ()
 
 endif (USE_PACKAGE_MANAGER)
-
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-  add_compile_definitions(DEBUG)
-elseif(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-  add_compile_definitions(DEBUG)
-endif()
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   link_libraries(dbghelp.lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,6 @@ set(_compile_definitions "")
 set(_link_libraries "")
 
 if ( ENABLE_DEBUG OR CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-  set(_CC_MOFILEREADER "# ")
   list(APPEND _compile_definitions DEBUG)
 endif ()
 

--- a/src/engine/Map.cxx
+++ b/src/engine/Map.cxx
@@ -426,6 +426,9 @@ Point Map::findNodeInMap(const SDL_Point &screenCoordinates) const
     isoY -= diff;
   }
 
+#ifdef DEBUG
+  int zOrder = INT_MAX;
+#endif
   // Transerse a column form from calculated coordinates to the bottom of the map.
   // It is necessary to include 2 neighbor nodes from both sides.
   // Try to find map node in Z order.
@@ -446,6 +449,11 @@ Point Map::findNodeInMap(const SDL_Point &screenCoordinates) const
     // Move y up and down 2 neighbors.
     for (int y = std::max(yMiddlePoint - neighborReach, 0); (y <= yMiddlePoint + neighborReach) && (y < mapSize); ++y)
     {
+#ifdef DEBUG
+      // Assert asumption that we test all nodes in correct Z order
+      assert(zOrder > mapNodes[x * m_columns + y]->getCoordinates().z);
+      zOrder = mapNodes[x * m_columns + y]->getCoordinates().z;
+#endif
       if (isClickWithinTile(screenCoordinates, x, y))
       {
         return mapNodes[x * m_columns + y]->getCoordinates();


### PR DESCRIPTION
Test results are attached. I would say roughly 2 times faster than older implementation.

Old implementation number of calls to the isClickWithinTile function.
Which node.
New implementation number of calls to the isClickWithinTile function.

May 02 17:34:29 - [INFO] - -----------------------------------------------------
May 02 17:34:29 - [INFO] - Old loops: 1017
May 02 17:34:29 - [INFO] - Found: 19 : 122
May 02 17:34:29 - [INFO] - New loops: 543
May 02 17:34:29 - [INFO] - -----------------------------------------------------

May 02 17:34:18 - [INFO] - -----------------------------------------------------
May 02 17:34:18 - [INFO] - Old loops: 1152
May 02 17:34:18 - [INFO] - Found: 0 : 125
May 02 17:34:18 - [INFO] - New loops: 628
May 02 17:34:18 - [INFO] - -----------------------------------------------------

May 02 17:34:31 - [INFO] - -----------------------------------------------------
May 02 17:31:56 - [INFO] - Old loops: 36
May 02 17:31:56 - [INFO] - Found: 127 : 126
May 02 17:31:56 - [INFO] - New loops: 3
May 02 17:31:56 - [INFO] - -----------------------------------------------------

May 02 17:31:33 - [INFO] - -----------------------------------------------------
May 02 17:31:34 - [INFO] - Old loops: 225
May 02 17:31:34 - [INFO] - Found: 107 : 105
May 02 17:31:34 - [INFO] - New loops: 103
May 02 17:31:34 - [INFO] - -----------------------------------------------------