### PR TITLE
use __android_log_print instad of cout for android logs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,14 @@ project(
         LANGUAGES CXX
 )
 
+if (APPLE)
+  set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15")
+  if(EXISTS("/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk"))
+    set(CMAKE_OSX_SYSROOT "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk")
+    message(STATUS "Setting OSX SDK to MacOSX10.15")
+  endif()
+endif()
+
 # on macOS, usr/local/lib is not in the default search path for libraries. Homebrew install it's libraries there though.
 if (APPLE AND NOT USE_PACKAGE_MANAGER)
     LINK_DIRECTORIES(${LINK_DIRECTORIES} /usr/local/lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,14 +71,6 @@ project(
         LANGUAGES CXX
 )
 
-if (APPLE)
-  set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15")
-  if(EXISTS("/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk"))
-    set(CMAKE_OSX_SYSROOT "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk")
-    message(STATUS "Setting OSX SDK to MacOSX10.15")
-  endif()
-endif()
-
 # on macOS, usr/local/lib is not in the default search path for libraries. Homebrew install it's libraries there though.
 if (APPLE AND NOT USE_PACKAGE_MANAGER)
     LINK_DIRECTORIES(${LINK_DIRECTORIES} /usr/local/lib)

--- a/src/util/LOG.cxx
+++ b/src/util/LOG.cxx
@@ -18,7 +18,7 @@ LOG::~LOG()
     if (m_LogType != LOG_DEBUG)
 #endif
 #ifdef __ANDROID__
-      __android_log_print(ANDROID_LOG_INFO, "Cytopia", "%s", Message.c_str());
+      __android_log_print(ANDROID_LOG_INFO, "Cytopia", "%s", message.c_str());
 #else
     std::cout << message << std::endl;
 #endif

--- a/src/util/LOG.cxx
+++ b/src/util/LOG.cxx
@@ -1,5 +1,9 @@
 #include "LOG.hxx"
 
+#ifdef __ANDROID__
+#include <android/log.h>
+#endif
+
 Mutex LOG::StreamMutex;
 
 LOG::LOG(LogType type) : m_LogType(type) {}
@@ -13,7 +17,11 @@ LOG::~LOG()
 #ifndef DEBUG
     if (m_LogType != LOG_DEBUG)
 #endif
-      std::cout << Message << std::endl;
+#ifdef __ANDROID__
+      __android_log_print(ANDROID_LOG_INFO, "Cytopia", "%s", Message.str().c_str());
+#else
+    std::cout << Message << std::endl;
+#endif
   }
   else
   {

--- a/src/util/LOG.cxx
+++ b/src/util/LOG.cxx
@@ -11,16 +11,16 @@ LOG::LOG(LogType type) : m_LogType(type) {}
 LOG::~LOG()
 {
   LockGuard lock(StreamMutex);
-  string Message = getTimeStamp() + LOG_PREFIX[m_LogType] + m_Logger.str();
+  string message = getTimeStamp() + LOG_PREFIX[m_LogType] + m_Logger.str();
   if (!getenv("TERM"))
   {
 #ifndef DEBUG
     if (m_LogType != LOG_DEBUG)
 #endif
 #ifdef __ANDROID__
-      __android_log_print(ANDROID_LOG_INFO, "Cytopia", "%s", Message.str().c_str());
+      __android_log_print(ANDROID_LOG_INFO, "Cytopia", "%s", Message.c_str());
 #else
-    std::cout << Message << std::endl;
+    std::cout << message << std::endl;
 #endif
   }
   else
@@ -30,7 +30,7 @@ LOG::~LOG()
 #endif
       std::cout << getTimeStamp() << LOG_PREFIX_COLORED[m_LogType] << m_Logger.str() << std::endl;
   }
-  writeErrorLog(Message);
+  writeErrorLog(message);
 }
 
 std::string LOG::getTimeStamp()


### PR DESCRIPTION
On Android, stdout is not written to the adb log. We have to use android_log_print instead.

I added it, but it doesn’t feature any other loglevels than info yet