### PR TITLE
fix sdl2_ttf build error

### DIFF
--- a/get_dependencies.sh
+++ b/get_dependencies.sh
@@ -16,12 +16,12 @@ rm SDL2_image-2.0.5.tar.gz
 mv SDL2_image-2.0.5 SDL2_image
 rm SDL2_image-2.0.5.tar.gz
 
-wget https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.0.4.tar.gz
-rm -rf SDL2_mixer
-tar xf SDL2_mixer-2.0.4.tar.gz
-rm SDL2_mixer-2.0.4.tar.gz
-mv SDL2_mixer-2.0.4 SDL2_mixer
-rm SDL2_mixer-2.0.4.tar.gz
+wget https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.0.15.tar.gz
+rm -rf SDL2_ttf
+tar xf SDL2_ttf-2.0.15.tar.gz
+rm SDL2_ttf-2.0.15.tar.gz
+mv SDL2_ttf-2.0.15 SDL2_ttf
+rm SDL2_ttf-2.0.15.tar.gz
 
 cd ..
 

--- a/get_dependencies.sh
+++ b/get_dependencies.sh
@@ -8,19 +8,19 @@ rm SDL2-2.0.9.tar.gz
 mv SDL2-2.0.9 SDL2
 rm SDL2-2.0.9.tar.gz
 
-wget https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.0.5.tar.gz
-rm -rf SDL2_image
-tar xf SDL2_image-2.0.5.tar.gz
-rm SDL2_image-2.0.5.tar.gz
-mv SDL2_image-2.0.5 SDL2_image
-rm SDL2_image-2.0.5.tar.gz
-
 wget https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.0.15.tar.gz
 rm -rf SDL2_ttf
 tar xf SDL2_ttf-2.0.15.tar.gz
 rm SDL2_ttf-2.0.15.tar.gz
 mv SDL2_ttf-2.0.15 SDL2_ttf
 rm SDL2_ttf-2.0.15.tar.gz
+
+wget https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.0.5.tar.gz
+rm -rf SDL2_image
+tar xf SDL2_image-2.0.5.tar.gz
+rm SDL2_image-2.0.5.tar.gz
+mv SDL2_image-2.0.5 SDL2_image
+rm SDL2_image-2.0.5.tar.gz
 
 cd ..
 

--- a/get_dependencies.sh
+++ b/get_dependencies.sh
@@ -1,4 +1,3 @@
-#!/bin/bash -x
 
 cd external/android/SDL
 


### PR DESCRIPTION
accidently removed sdl2_ttf instead of sdl2_mixer for android.