### PR TITLE
Fix possible crash when calling TileManager::getRandomTileIDForZoneWithRandomSize

### DIFF
--- a/src/engine/TileManager.cxx
+++ b/src/engine/TileManager.cxx
@@ -40,7 +40,7 @@ std::vector<std::string> TileManager::getAllTileIDsForZone(Zones zone, TileSize 
   return results;
 }
 
-const std::string &TileManager::getRandomTileIDForZoneWithRandomSize(Zones zone, TileSize maxTileSize)
+std::string TileManager::getRandomTileIDForZoneWithRandomSize(Zones zone, TileSize maxTileSize)
 {
   std::unordered_set<TileSize> elligibleTileSizes;
 

--- a/src/engine/TileManager.hxx
+++ b/src/engine/TileManager.hxx
@@ -131,7 +131,7 @@ public:
    * @param maxTileSize - maximum tileSize we want 
    * @return A random tileID matching the supplied parameters
    */
-  const std::string &getRandomTileIDForZoneWithRandomSize(Zones zone, TileSize maxTileSize = {1, 1});
+  std::string getRandomTileIDForZoneWithRandomSize(Zones zone, TileSize maxTileSize = {1, 1});
 
   /**
  * @brief Parse the tileData JSON and set up the tileManager


### PR DESCRIPTION
Returning a reference to a stack variable is UB.