### PR TITLE
Fix z order

### DIFF
--- a/src/engine/GameObjects/MapNode.hxx
+++ b/src/engine/GameObjects/MapNode.hxx
@@ -172,6 +172,12 @@ public:
   void setNodeTransparency(const float transparencyFactor, const Layer &layer) const;
 
   /**
+  * Update the Z-Index of this mapNode
+  * @param the new Z-Index
+  */
+  void setZIndex(int zIndex) { m_isoCoordinates.z = zIndex; };
+
+  /**
    * @brief Maximum height of the node.
    */
   static const int maxHeight = 32;

--- a/src/engine/Map.cxx
+++ b/src/engine/Map.cxx
@@ -743,9 +743,10 @@ void Map::calculateVisibleMap(void)
 
   m_visibleNodesCount = 0;
 
-  for (int x = 0; x < m_rows; x++)
+  // ZOrder starts from topmost node to the right. (0,127) =1,(1,127) =2, ...
+  for (int y = m_columns - 1; y >= 0; y--)
   {
-    for (int y = m_columns - 1; y >= 0; y--)
+    for (int x = 0; x < m_rows; x++)
     {
       const int xVal = x + y;
       const int yVal = y - x;

--- a/src/engine/map/TerrainGenerator.cxx
+++ b/src/engine/map/TerrainGenerator.cxx
@@ -93,7 +93,7 @@ void TerrainGenerator::generateTerrain(std::vector<MapNode> &mapNodes, std::vect
   {
     for (int y = 0; y < mapSize; y++)
     {
-      const int z = (x + 1) * mapSize - y - 1;
+      const int z = 0; // it's not possible to calculate the correct z-index, so set it later in a for loop
       double rawHeight = terrainHeight.GetValue(x * 32, y * 32, 0.5);
       int height = static_cast<int>(rawHeight);
 
@@ -148,10 +148,14 @@ void TerrainGenerator::generateTerrain(std::vector<MapNode> &mapNodes, std::vect
     }
   }
 
-  for (int x = 0; x < mapSize; x++)
+  int z = 0;
+  // set the z-Index for the mapNodes. It is not used, but it's better to have the correct z-index set
+  for (int y = mapSize - 1; y >= 0; y--)
   {
-    for (int y = mapSize - 1; y >= 0; y--)
+    for (int x = 0; x < mapSize; x++)
     {
+      z++;
+      mapNodes[x * mapSize + y].setZIndex(z);
       mapNodesInDrawingOrder.push_back(&mapNodes[x * mapSize + y]);
     }
   }


### PR DESCRIPTION
- Fixed the order in which tiles are drawn
- Fixed z-order coordinate in mapnodes (which was always utterly wrong, but never used)
- Added an option to set z index for map nodes (it's not possible to set it otherwise and i don't understand the terrain gen code enough to make changes there)

The coordinates origin (0,0) is the top left node. So i changed the order in which the tiles are rendered.

Nodes are now rendered in this order:
![grafik](https://user-images.githubusercontent.com/7029836/163199085-6985e10a-85a6-48ba-b60c-c57a902c9927.png)

Fixes  #404
Fixes #419 
Fixes #726
Fixes #725