### PR TITLE
Add options to build with ASan/UBSan/TSan

### DIFF
--- a/.github/workflows/build-game.yml
+++ b/.github/workflows/build-game.yml
@@ -136,6 +136,129 @@ jobs:
           butler push redist cytopia/cytopia:linux-ci --userversion CIBuild-${GITHUB_RUN_NUMBER}-commit-${GITHUB_SHA}
         shell: bash
 
+  build-clang-asan-ubsan:
+    name: Build Linux (Clang ASan/UBSan)
+    env:
+      sccache_CACHE_SIZE: 500M
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Prepare sccache timestamp
+        id: sccache_cache_timestamp
+        shell: cmake -P {0}
+        run: |
+          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+          message("::set-output name=timestamp::${current_date}")
+
+      - name: sccache cache files
+        uses: actions/cache@v2.1.7
+        with:
+          path: ~/.cache/sccache
+          key: clang-asan-ubsan-sccache-${{ steps.sccache_cache_timestamp.outputs.timestamp }}
+          restore-keys: |
+            clang-asan-ubsan-sccache-
+
+      - name: Install dependencies
+        run: |
+          echo -e 'pcm.!default {\n type plug\n slave.pcm "null"\n}' > ~/.asoundrc
+          sudo apt-get update
+          sudo apt-get -y install \
+                  ninja-build \
+                  doxygen \
+                  graphviz \
+                  fakeroot \
+                  libarchive-tools \
+                  zstd \
+                  gettext \
+                  libsdl2-dev \
+                  libsdl2-image-dev \
+                  libsdl2-ttf-dev \
+                  libopenal-dev \
+                  libvorbis-dev \
+                  libpng-dev \
+                  libnoise-dev \
+                  clang-12
+          curl "https://raw.githubusercontent.com/AnotherFoxGuy/ci-scripts/main/install-cmake.sh" | sudo bash
+          curl "https://raw.githubusercontent.com/AnotherFoxGuy/ci-scripts/main/install-sccache.sh" | sudo bash
+        shell: bash
+
+      - name: Build
+        run: |
+          CC=clang-12 CXX=clang++-12 cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DENABLE_ASAN=ON -DENABLE_UBSAN=ON .
+          ninja
+          sccache --show-stats
+        shell: bash
+
+      - name: Test
+        uses: GabrielBB/xvfb-action@v1.6
+        with:
+          run: ctest -VV
+
+  build-clang-tsan:
+    name: Build Linux (Clang TSan)
+    env:
+      sccache_CACHE_SIZE: 500M
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Prepare sccache timestamp
+        id: sccache_cache_timestamp
+        shell: cmake -P {0}
+        run: |
+          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+          message("::set-output name=timestamp::${current_date}")
+
+      - name: sccache cache files
+        uses: actions/cache@v2.1.7
+        with:
+          path: ~/.cache/sccache
+          key: clang-tsan-sccache-${{ steps.sccache_cache_timestamp.outputs.timestamp }}
+          restore-keys: |
+            clang-tsan-sccache-
+
+      - name: Install dependencies
+        run: |
+          echo -e 'pcm.!default {\n type plug\n slave.pcm "null"\n}' > ~/.asoundrc
+          sudo apt-get update
+          sudo apt-get -y install \
+                  ninja-build \
+                  doxygen \
+                  graphviz \
+                  fakeroot \
+                  libarchive-tools \
+                  zstd \
+                  gettext \
+                  libsdl2-dev \
+                  libsdl2-image-dev \
+                  libsdl2-ttf-dev \
+                  libopenal-dev \
+                  libvorbis-dev \
+                  libpng-dev \
+                  libnoise-dev \
+                  clang-12
+          curl "https://raw.githubusercontent.com/AnotherFoxGuy/ci-scripts/main/install-cmake.sh" | sudo bash
+          curl "https://raw.githubusercontent.com/AnotherFoxGuy/ci-scripts/main/install-sccache.sh" | sudo bash
+        shell: bash
+
+      - name: Build
+        run: |
+          CC=clang-12 CXX=clang++-12 cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DENABLE_TSAN=ON .
+          ninja
+          sccache --show-stats
+        shell: bash
+
+      - name: Test
+        uses: GabrielBB/xvfb-action@v1.6
+        with:
+          run: ctest -VV
+
+
   build-appleclang:
     name: Build Mac
     env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,9 @@ option(${_PREFIX}FORCE_SYSTEM_DEPENDENCIES "Force the use of system packages")
 
 option(BUILD_TEST "Build Cytopia Tests" ON)
 option(ENABLE_DEBUG "Enable Debug (asserts and logs)" OFF)
+option(ENABLE_ASAN "Enable Address Sanitizer" OFF)
+option(ENABLE_UBSAN "Enable Undefined Behaviour Sanitizer" OFF)
+option(ENABLE_TSAN "Enable Thread Sanitizer" OFF)
 
 # setup paths
 set(RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -190,6 +190,22 @@ if (USE_ANGELSCRIPT)
     target_compile_definitions(${PROJECT_NAME} PRIVATE USE_ANGELSCRIPT)
 endif ()
 
+if (ENABLE_ASAN)
+	target_compile_options(${PROJECT_NAME} PUBLIC -fsanitize=address -fno-sanitize-recover=all)
+	target_link_options(${PROJECT_NAME} PUBLIC -fsanitize=address)
+endif ()
+
+if (ENABLE_UBSAN)
+	target_compile_options(${PROJECT_NAME} PUBLIC -fsanitize=undefined -fno-sanitize-recover=all)
+	target_link_options(${PROJECT_NAME} PUBLIC -fsanitize=undefined)
+endif ()
+
+if (ENABLE_TSAN)
+	target_compile_options(${PROJECT_NAME} PUBLIC -fsanitize=thread -fno-sanitize-recover=all)
+	target_link_options(${PROJECT_NAME} PUBLIC -fsanitize=thread)
+endif ()
+
+
 # copy the resources to the compiled directory. On Apple those files are used from the resources dir, not from the root dir.
 if (NOT APPLE)
     fast_copy("${CMAKE_SOURCE_DIR}/data/resources" "${RUNTIME_OUTPUT_DIRECTORY}/resources")


### PR DESCRIPTION
This adds CI checks and CMake options to enable Address/Undefined Behaviour/Thread Sanitizers (https://github.com/google/sanitizers/) which are available for GCC and Clang.
This improves detection of things like buffer overruns, integer overflows and data races.