### PR TITLE
Fix compilation error by adding missing header-file definition

### DIFF
--- a/src/services/GameClock.inl.hxx
+++ b/src/services/GameClock.inl.hxx
@@ -1,3 +1,4 @@
+#include <cassert>
 #include "LOG.hxx"
 
 template <typename DelayType, typename PeriodType>


### PR DESCRIPTION
Summary:
`assert` is not defined in template header file. 

Compiler states: 
* `error: there are no arguments to ‘assert’ that depend on a template parameter, so a declaration of ‘assert’ must be available`