### PR TITLE
Add a setting option to write the error log to a file

### DIFF
--- a/data/resources/settings.json
+++ b/data/resources/settings.json
@@ -36,5 +36,9 @@
         "Language": "en",
         "SubMenuButtonHeight": 32,
         "SubMenuButtonWidth": 32
+    },
+    "Debug": {
+      "WriteErrorLogToFile": false
+
     }
 }

--- a/src/engine/basics/Settings.cxx
+++ b/src/engine/basics/Settings.cxx
@@ -1,6 +1,6 @@
 #include "Settings.hxx"
 
-#include "LOG.hxx"
+// #include "LOG.hxx"
 #include "Exception.hxx"
 #include "Constants.hxx"
 #include "JsonSerialization.hxx"

--- a/src/engine/basics/Settings.hxx
+++ b/src/engine/basics/Settings.hxx
@@ -61,7 +61,7 @@ struct SettingsData
   * where 0 is full opaque and 1 for full transparency.
   */
   float zoneLayerTransparency;
-  
+
   /**
    * @todo document what this field is
    * @todo add a typename
@@ -118,7 +118,7 @@ struct SettingsData
    */
   std::string buildMenuPosition;
 
-    /**
+  /**
    * @brief this is used for biomedata
    * @todo Remove this later when terraingen is using biomes
    * @todo replace by enum when BetterEnums is implemented
@@ -179,6 +179,12 @@ struct SettingsData
    * @brief Indicates whether we want to see buildings inside Blueprint layer or not.
    */
   bool showBuildingsInBlueprint;
+
+  /**
+   * @brief Write errors to a log file
+   * 
+   */
+  bool writeErrorLogFile;
 };
 
 /**

--- a/src/engine/common/JsonSerialization.hxx
+++ b/src/engine/common/JsonSerialization.hxx
@@ -59,6 +59,7 @@ inline void from_json(const json &j, SettingsData &s)
   s.fontFileName = j["User Interface"].value("FontFilename", "resources/fonts/arcadeclassics.ttf");
   s.subMenuButtonWidth = j["User Interface"].value("SubMenuButtonWidth", 32);
   s.subMenuButtonHeight = j["User Interface"].value("SubMenuButtonHeight", 32);
+  s.writeErrorLogFile = j["Debug"].value("WriteErrorLogToFile", false);
 }
 
 // JSON deserializer for BiomeData struct (Terrain Gen)

--- a/src/util/Exception.hxx
+++ b/src/util/Exception.hxx
@@ -6,6 +6,10 @@
 
 #define ERROR_MSG "In file " __BOLD__ __RED__ __FILE__ ":" __line__ __CLEAR__ "\n\t"
 #define NESTED_MSG "Called from " __BOLD__ __RED__ __FILE__ ":" __line__ __CLEAR__ "\n\t"
+#define STRINGIFY(x) #x
+#define STRINGIFY2(x) STRINGIFY(x)
+#define __line__ STRINGIFY2(__LINE__)
+#define TRACE_INFO "Exception thrown from " + string(__PRETTY_FUNCTION__) + " at " __FILE__ ":" __line__ " - "
 
 using RuntimeError = std::runtime_error;
 

--- a/src/util/Exception.hxx
+++ b/src/util/Exception.hxx
@@ -11,6 +11,15 @@
 #define __line__ STRINGIFY2(__LINE__)
 #define TRACE_INFO "Exception thrown from " + string(__PRETTY_FUNCTION__) + " at " __FILE__ ":" __line__ " - "
 
+// Required to use std::getenv without warning on MSVC
+#define _CRT_SECURE_NO_WARNINGS
+
+#if _MSC_VER && !__INTEL_COMPILER
+#define __PRETTY_FUNCTION__ __FUNCSIG__
+#elif __INTEL_COMPILER
+#define __PRETTY_FUNCTION__ "Unknown_Method"
+#endif
+
 using RuntimeError = std::runtime_error;
 
 /**

--- a/src/util/LOG.cxx
+++ b/src/util/LOG.cxx
@@ -1,5 +1,6 @@
 #include "LOG.hxx"
 #include "Filesystem.hxx"
+#include "Settings.hxx"
 
 #ifdef __ANDROID__
 #include <android/log.h>
@@ -32,7 +33,10 @@ LOG::~LOG()
       std::cout << getTimeStamp() << LOG_PREFIX_COLORED[m_LogType] << m_Logger.str() << std::endl;
   }
 #ifndef __ANDROID__
-  writeErrorLog(message);
+  if (Settings::instance().writeErrorLogFile)
+  {
+    writeErrorLog(message);
+  }
 #endif
 }
 

--- a/src/util/LOG.hxx
+++ b/src/util/LOG.hxx
@@ -4,15 +4,6 @@
 #include <string>
 #include "Exception.hxx"
 
-// Required to use std::getenv without warning on MSVC
-#define _CRT_SECURE_NO_WARNINGS
-
-#if _MSC_VER && !__INTEL_COMPILER
-#define __PRETTY_FUNCTION__ __FUNCSIG__
-#elif __INTEL_COMPILER
-#define __PRETTY_FUNCTION__ "Unknown_Method"
-#endif
-
 #include <iostream>
 #include <chrono>
 #include <ctime>

--- a/src/util/LOG.hxx
+++ b/src/util/LOG.hxx
@@ -4,11 +4,6 @@
 #include <string>
 #include "Exception.hxx"
 
-#define STRINGIFY(x) #x
-#define STRINGIFY2(x) STRINGIFY(x)
-#define __line__ STRINGIFY2(__LINE__)
-#define TRACE_INFO "Exception thrown from " + string(__PRETTY_FUNCTION__) + " at " __FILE__ ":" __line__ " - "
-
 // Required to use std::getenv without warning on MSVC
 #define _CRT_SECURE_NO_WARNINGS
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,7 +26,7 @@ LIST(APPEND TEST_SOURCES
         ui/widgets/Text.cxx
         util/Meta.cxx
         util/MessageQueue.cxx
-        util/LOG.cxx
+        # util/LOG.cxx // disabled because log files are no longer written per default
         )
 
 # Generate source groups for use in IDEs


### PR DESCRIPTION
Sometimes we're not allowed to write new files, and the error log isn't needed in most cases, so don't write it if not explicitly enabled.