### PR TITLE
Minor refactor for codebase to prefer constructor initializer lists

### DIFF
--- a/src/engine/GameObjects/MapNode.cxx
+++ b/src/engine/GameObjects/MapNode.cxx
@@ -7,27 +7,11 @@
 #include "Settings.hxx"
 
 MapNode::MapNode(Point isoCoordinates, const std::string &terrainID, const std::string &tileID)
-    : m_isoCoordinates(std::move(isoCoordinates))
+    : m_isoCoordinates(std::move(isoCoordinates)), m_sprite{std::make_unique<Sprite>(m_isoCoordinates)},
+      m_autotileOrientation(LAYERS_COUNT, TileOrientation::TILE_DEFAULT_ORIENTATION),
+      m_mapNodeData{std::vector(LAYERS_COUNT, MapNodeData{"", nullptr, 0, m_isoCoordinates, true, TileMap::DEFAULT})},
+      m_autotileBitmask(LAYERS_COUNT)
 {
-  m_mapNodeData.resize(LAYERS_COUNT);
-  m_autotileBitmask.resize(LAYERS_COUNT);
-  m_autotileOrientation.resize(LAYERS_COUNT);
-  m_sprite = std::make_unique<Sprite>(m_isoCoordinates);
-
-  //initialize vectors
-  for (auto &it : m_autotileBitmask)
-  {
-    it = 0;
-  }
-  for (auto &it : m_autotileOrientation)
-  {
-    it = TileOrientation::TILE_DEFAULT_ORIENTATION;
-  }
-  for (auto &it : m_mapNodeData)
-  {
-    it.origCornerPoint = isoCoordinates;
-  }
-
   setTileID(terrainID, isoCoordinates);
   if (!tileID.empty()) // in case tileID is not supplied skip it
   {


### PR DESCRIPTION
As titled.

---
Some reasons for changeset:
* Recommended and helpful suggestion from the C++ Core Guidelines:
  [C.49: Prefer initialization to assignment in constructors.](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c49-prefer-initialization-to-assignment-in-constructors)
* Size of codebase is reduced.

---

Great project BTW! :tada: