### PR TITLE
game: Implement `namespace Cytopia`

### DIFF
--- a/src/Game.cxx
+++ b/src/Game.cxx
@@ -25,6 +25,8 @@
 #include "microprofile/microprofile.h"
 #endif
 
+namespace Cytopia
+{
 Game::Game() { LOG(LOG_DEBUG) << "Created Game Object"; }
 
 void Game::quit()
@@ -370,3 +372,4 @@ void Game::shutdown()
   TTF_Quit();
   SDL_Quit();
 }
+} // namespace Cytopia

--- a/src/Game.hxx
+++ b/src/Game.hxx
@@ -23,6 +23,8 @@
 using Thread = std::thread;
 using RuntimeError = std::runtime_error;
 
+namespace Cytopia
+{
 class Game
 {
 public:
@@ -62,5 +64,5 @@ public:
 private:
   void quit();
 };
-
+} // namespace Cytopia
 #endif

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -30,7 +30,7 @@ int protected_main(int argc, char **argv)
 
   LOG(LOG_DEBUG) << "Launching Cytopia";
 
-  Game game;
+  Cytopia::Game game;
 
   LOG(LOG_DEBUG) << "Initializing Cytopia";
 


### PR DESCRIPTION
* Implements `namespace Cytopia` to a variety of translation units.
* This PR's changeset moves various functions (function symbols) off the `global` namespace.
* This PR is needed / advisable as it helps improve argument-dependent lookups (ADL), software debugging, reduces pollution of the global namespace and namespace-encapsulation of various datatypes.

---
_For example:_

Before changeset:
* Previously the translation unit's function `Game::run` (symbol) was "listed" under the `global` namespace.
```
./src/CMakeFiles/Cytopia.dir/Game.cxx.o:0000000000001222 T _ZN4Game3runEb
```

After changeset:
* `Game::run` is now correctly aliased behind / as part of the `Cytopia` namespace.

```
./src/CMakeFiles/Cytopia.dir/Game.cxx.o:0000000000001222 T _ZN7Cytopia4Game3runEb
```
---

Further future PRs  / changesets will encapsulate progressively the rest of the translation units symbols.
