### PR TITLE
Implement middle click eyedropper tool feature

### DIFF
--- a/src/engine/EventManager.cxx
+++ b/src/engine/EventManager.cxx
@@ -542,6 +542,21 @@ void EventManager::checkEvents(SDL_Event &event, Engine &engine)
       // game event handling
       mouseScreenCoords = {event.button.x, event.button.y};
       mouseIsoCoords = convertScreenToIsoCoordinates(mouseScreenCoords);
+
+      // select the tile our cursor is over
+      if (tileToPlace.empty()) {
+        MapNode &node = engine.map->getMapNode(mouseIsoCoords);
+        Layer topMostActiveLayer = node.getTopMostActiveLayer();
+        // all layers are supported except terrain
+        if(topMostActiveLayer == Layer::TERRAIN || topMostActiveLayer == Layer::NONE)
+          break;
+        std::vector<MapNodeData> mapNodeData = node.getMapNodeData();
+        tileToPlace = mapNodeData[topMostActiveLayer].tileID;
+        highlightSelection = true;
+        // pick the tile in mousemove, player will find mousedown
+        break;
+      }
+
       // gather all nodes the objects that'll be placed is going to occupy.
       std::vector targetObjectNodes = TileManager::instance().getTargetCoordsOfTileID(mouseIsoCoords, tileToPlace);
 

--- a/src/engine/EventManager.hxx
+++ b/src/engine/EventManager.hxx
@@ -20,6 +20,7 @@ public:
  * @details This sets a node to be unhighlighted.
  */
   void unHighlightNodes();
+  void pickTileUnderCursor(Point mouseIsoCoords);
 
 private:
   UIManager &m_uiManager = UIManager::instance();

--- a/src/engine/GameObjects/MapNode.cxx
+++ b/src/engine/GameObjects/MapNode.cxx
@@ -104,26 +104,12 @@ void MapNode::setTileID(const std::string &tileID, const Point &origCornerPoint)
 
 Layer MapNode::getTopMostActiveLayer() const
 {
-  if (MapLayers::isLayerActive(Layer::BUILDINGS) && m_mapNodeData[Layer::BUILDINGS].tileData)
+  for (auto currentLayer : layersInActiveOrder)
   {
-    return Layer::BUILDINGS;
-  }
-  else if (MapLayers::isLayerActive(Layer::BLUEPRINT) && m_mapNodeData[Layer::UNDERGROUND].tileData)
-  {
-    return Layer::UNDERGROUND;
-  }
-  else if (MapLayers::isLayerActive(Layer::BLUEPRINT) && m_mapNodeData[Layer::BLUEPRINT].tileData)
-  {
-    return Layer::BLUEPRINT;
-  }
-  else if (MapLayers::isLayerActive(Layer::GROUND_DECORATION) && m_mapNodeData[Layer::GROUND_DECORATION].tileData)
-  {
-    return Layer::GROUND_DECORATION;
-  }
-  // terrain is our fallback, since there's always terrain.
-  else if (MapLayers::isLayerActive(Layer::TERRAIN) && m_mapNodeData[Layer::TERRAIN].tileData)
-  {
-    return Layer::TERRAIN;
+    if (MapLayers::isLayerActive(currentLayer) && m_mapNodeData[currentLayer].tileData)
+    {
+      return currentLayer;
+    }
   }
   return Layer::NONE;
 }

--- a/src/engine/Map.cxx
+++ b/src/engine/Map.cxx
@@ -718,21 +718,21 @@ void Map::calculateVisibleMap(void)
   }
 }
 
-void Map::setTileID(const std::string &tileID, Point coordinate)
+bool Map::setTileID(const std::string &tileID, Point coordinate)
 {
   TileData *tileData = TileManager::instance().getTileData(tileID);
   std::vector<Point> targetCoordinates = TileManager::instance().getTargetCoordsOfTileID(coordinate, tileID);
 
   if (!tileData || targetCoordinates.empty())
   { // if the node would not outside of map boundaries, targetCoordinates would be empty
-    return;
+    return false;
   }
 
   for (auto coord : targetCoordinates)
   { // first check all nodes if it is possible to place the building before doing anything
     if (!isPlacementOnNodeAllowed(coord, tileID))
     { //make sure every target coordinate is valid for placement, not just the origin coordinate.
-      return;
+      return false;
     }
   }
 
@@ -812,12 +812,15 @@ void Map::setTileID(const std::string &tileID, Point coordinate)
   {
     updateNodeNeighbors(nodesToBeUpdated);
   }
+  return true;
 }
 
-void Map::setTileID(const std::string &tileID, const std::vector<Point> &coordinates)
+bool Map::setTileID(const std::string &tileID, const std::vector<Point> &coordinates)
 {
+  bool setTileResult = true;
   for (auto coord : coordinates)
   {
-    setTileID(tileID, coord);
+    setTileResult &= setTileID(tileID, coord);
   }
+  return setTileResult;
 }

--- a/src/engine/Map.hxx
+++ b/src/engine/Map.hxx
@@ -78,16 +78,18 @@ public:
  * @details Also invokes all necessary texture updates (auto-tiling, slopes, ...)
  * @param tileID the new tileID to set
  * @param coordinate Point where the tileID which should be set
+ * @returns setTileID success or not
  */
-  void setTileID(const std::string &tileID, Point coordinate);
+  bool setTileID(const std::string &tileID, Point coordinate);
 
   /**
  * @brief Set the Tile ID Of multiple Node objects
  * @details Also invokes all necessary texture updates (auto-tiling, slopes, ...)
  * @param tileID the new tileID to set
  * @param coordinates a vector of Points where the tileIDs which should be set
+ * @returns setTileID success or not
  */
-  void setTileID(const std::string &tileID, const std::vector<Point> &coordinates);
+  bool setTileID(const std::string &tileID, const std::vector<Point> &coordinates);
 
   /**
  * @brief Demolish a node

--- a/src/engine/common/enums.hxx
+++ b/src/engine/common/enums.hxx
@@ -29,6 +29,11 @@ static Layer allLayersOrdered[] = {
     Layer::BLUEPRINT, Layer::UNDERGROUND, Layer::TERRAIN,    Layer::WATER, Layer::GROUND_DECORATION,
     Layer::ZONE,      Layer::ROAD,        Layer::POWERLINES, Layer::FLORA, Layer::BUILDINGS};
 
+/// This is a ordered list of all relevant layers from the most active to the least active
+static Layer layersInActiveOrder[] = {
+  Layer::BUILDINGS, Layer::UNDERGROUND, Layer::BLUEPRINT, Layer::GROUND_DECORATION,
+  Layer::ROAD, Layer::POWERLINES, Layer::FLORA, Layer::ZONE, Layer::WATER, Layer::TERRAIN};
+
 /**
  * @brief LayerEditMode.
  * This enum is for switching between layers.


### PR DESCRIPTION
## Overview

Middle click eyedropper tool feature is supported now!

We can pick nearly all kinds of object in the map like buildings, powerlines, flora, etc. Just like what we have to do in the UI elements.

## Video
https://user-images.githubusercontent.com/41318515/167623154-647f9e72-0202-4965-b4b8-c51f741291b3.mov

## Issues

Related issue: #910 