### PR TITLE
Multi-tile placement (#800)

### DIFF
--- a/src/engine/EventManager.cxx
+++ b/src/engine/EventManager.cxx
@@ -19,16 +19,19 @@
 
 void EventManager::unHighlightNodes()
 {
-  for (auto node : m_nodesToPlace)
+  if(!m_isPuttingTile)
   {
-    Engine::instance().map->unHighlightNode(node);
+    for (auto node : m_nodesToPlace)
+    {
+      Engine::instance().map->unHighlightNode(node);
+    }
+    m_nodesToPlace.clear();
   }
   for (auto node : m_nodesToHighlight)
   {
     Engine::instance().map->unHighlightNode(node);
   }
   m_nodesToHighlight.clear();
-  m_nodesToPlace.clear();
 }
 
 void EventManager::pickTileUnderCursor(Point mouseIsoCoords)
@@ -497,6 +500,7 @@ void EventManager::checkEvents(SDL_Event &event, Engine &engine)
           {
             m_nodesToPlace.push_back(mouseIsoCoords);
           }
+          m_isPuttingTile = true;
         }
       }
       break;
@@ -541,6 +545,7 @@ void EventManager::checkEvents(SDL_Event &event, Engine &engine)
       // If we're over a ui element, don't handle game events
       if (m_skipLeftClick)
       {
+        m_isPuttingTile = false;
         break;
       }
 
@@ -587,6 +592,7 @@ void EventManager::checkEvents(SDL_Event &event, Engine &engine)
         }
       }
       // when we're done, reset highlighting
+      m_isPuttingTile = false;
       unHighlightNodes();
 
       if (highlightSelection)

--- a/src/engine/EventManager.hxx
+++ b/src/engine/EventManager.hxx
@@ -32,6 +32,7 @@ private:
   bool m_panning = false;
   bool m_skipLeftClick = false;
   bool m_tileInfoMode = false;
+  bool m_isPuttingTile = false; ///< determines if putting tile action is being performed
   bool m_cancelTileSelection = false; ///< determines if a right click should cancel tile selection
   Point m_pinchCenterCoords = {0, 0, 0, 0};
   Point m_clickDownCoords = {0, 0, 0, 0};


### PR DESCRIPTION
This pr provided an ad-hoc solution to #800. A flag is used to protect the action of putting a tile. After implemented this, multi tile placement will always work well in my environment(Mac).

The event manager should to be refactored, this pr might be a temporary fix to the annoying bug.