### PR TITLE
cmake: windows: fix visual studio solution generation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -224,6 +224,12 @@ if (MSVC)
             PROPERTIES
             VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
     )
+    target_include_directories(
+            ${PROJECT_NAME}
+            PRIVATE
+            ${CONAN_INCLUDE_DIRS_RELWITHDEBINFO}
+            ${CONAN_INCLUDE_DIRS_DEBUG}
+            ${CONAN_INCLUDE_DIRS_RELEASE})
 endif ()
 
 install(TARGETS ${PROJECT_NAME} DESTINATION .)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -71,6 +71,17 @@ target_include_directories(
         ${CMAKE_SOURCE_DIR}/src/services
 )
 
+if (MSVC)
+    # set startup project for Visual Studio Builds
+    target_include_directories(
+            ${PROJECT_NAME}
+            PRIVATE
+            ${CONAN_INCLUDE_DIRS_RELWITHDEBINFO}
+            ${CONAN_INCLUDE_DIRS_DEBUG}
+            ${CONAN_INCLUDE_DIRS_RELEASE}
+    )
+endif ()
+
 target_compile_definitions(${TESTS_PROJECT_NAME} PRIVATE ${_compile_definitions})
 target_link_libraries(
         ${TESTS_PROJECT_NAME} PRIVATE

--- a/tests/main.cxx
+++ b/tests/main.cxx
@@ -1,6 +1,6 @@
 #define CATCH_CONFIG_MAIN
 #include <catch.hpp>
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 /*
  * This file should remain empty.


### PR DESCRIPTION
why: dependencies include headers not attended to solution via cmake