### PR TITLE
MapFunction: allow place on part of the area for water and flora

### DIFF
--- a/src/engine/map/MapFunctions.cxx
+++ b/src/engine/map/MapFunctions.cxx
@@ -210,15 +210,15 @@ bool MapFunctions::isPlacementOnAreaAllowed(const std::vector<Point> &targetCoor
   bool tilePlacementAllowed = true;
 
   const Layer layer = TileManager::instance().getTileLayer(tileID);
-  // Zone layer can be placed on part of tile in the area.
-  // Some other layers can also have this feature, such as water, flora.
-  if (layer == Layer::ZONE)
+  // Only buildings and roads has to be placed on all of the tile selected.
+  // Other layers can be placed on part of tile in the area, such as zone, water, flora.
+  if (layer == BUILDINGS)
   {
-    shouldAllNodesPlaced = false;
+    shouldAllNodesPlaced = true;
   }
   else
   {
-    shouldAllNodesPlaced = true;
+    shouldAllNodesPlaced = false;
   }
   areaPlacementAllowed = shouldAllNodesPlaced;
 


### PR DESCRIPTION
Allow place water or flora on an area when some tiles in the area is not allowed to place. This will let the player operate more conveniently.

For example, the below issue will not happen again.

![IMG_3284](https://user-images.githubusercontent.com/41318515/169978976-77516eca-4c92-4290-9860-b8d5c1a23706.jpeg)
