### PR TITLE
ZoneManager: fix not connected powergrid affect powersupply bug

### DIFF
--- a/src/game/ZoneManager.cxx
+++ b/src/game/ZoneManager.cxx
@@ -202,14 +202,16 @@ void ZoneManager::updatePower(const std::vector<PowerGrid> &powerGrid)
     for (auto &area : m_zoneAreas)
     {
       isGridConnected = area.end() != std::find_if(area.begin(), area.end(),
-                                                   [grid](const ZoneNode &node) { return grid.isNeighbor(node.coordinate); });
-      if (isGridConnected && grid.getPowerLevel() > 0)
-      {
-        area.setPowerSupply(true);
-      }
-      else
-      {
-        area.setPowerSupply(false);
+          [grid](const ZoneNode &node) { return grid.isNeighbor(node.coordinate); });
+      if (isGridConnected) {
+        if(grid.getPowerLevel() > 0)
+        {
+          area.setPowerSupply(true);
+        }
+        else
+        {
+          area.setPowerSupply(false);
+        }
       }
     }
   }


### PR DESCRIPTION
## Overview

Power supply should not be affected by not connected powergrid. Current implementation left a bug on it which leads to zone stops spawn when placing any building not connected to that zone.

## Related issue

Fix bug #952