### PR TITLE
added missing prerequisites, libpng

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Mac
 - [libnoise](http://libnoise.sourceforge.net/)
 - [libogg](https://www.xiph.org/ogg/)
 - [libvorbis](https://www.xiph.org/vorbis/)
+- [libpng](http://www.libpng.org/pub/png/libpng.html)
 
 #### Build instructions
 


### PR DESCRIPTION
while building on Linux noticed that this library missing from prerequisites 

added missing prerequisites, libpng