### PR TITLE
Separated music and sfx

### DIFF
--- a/src/engine/audio/Soundtrack.cxx
+++ b/src/engine/audio/Soundtrack.cxx
@@ -6,7 +6,7 @@
 Soundtrack::Soundtrack(SoundtrackID id, ChannelID channelID, DecodedAudioData *dAudioData, RepeatCount repeat, bool isMusic,
                        bool isPlaying, bool isPlayable, bool isTriggerable)
     : ID(id), Channel(channelID), Loop(repeat), isMusic(isMusic), isPlaying(isPlaying), isTriggerable(isTriggerable),
-      isPlayable(isPlayable), source(0), buffer(0)
+      isPlayable(isPlayable), source(), buffer(0)
 {
 
   /* initialize buffer */
@@ -25,21 +25,22 @@ Soundtrack::Soundtrack(SoundtrackID id, ChannelID channelID, DecodedAudioData *d
   if (errorCode != AL_NO_ERROR)
     throw AudioError(TRACE_INFO "Failed to load audio data into buffer: Error " + std::to_string(errorCode));
 
-  /* initialize source */
-  alGenSources(1, &source);
-  alSourcei(source, AL_SOURCE_RELATIVE, AL_FALSE);
+  /* initialize sources */
+  alGenSources(2, source);
+  alSourcei(source[0], AL_SOURCE_RELATIVE, AL_FALSE); // sfx channel/source
+  alSourcei(source[1], AL_SOURCE_RELATIVE, AL_FALSE); // music channel/source
   errorCode = alGetError();
   if (errorCode != AL_NO_ERROR)
     throw AudioError(TRACE_INFO "Failed to setup sound source: Error " + std::to_string(errorCode));
 
   /* attach buffer to source */
-  alSourcei(source, AL_BUFFER, buffer);
+  alSourcei(source[isMusic], AL_BUFFER, buffer);
 }
 
 Soundtrack::~Soundtrack()
 {
-  if (alIsSource(source))
-    alDeleteSources(1, &source);
+  if (alIsSource(source[0]))
+    alDeleteSources(2, source);
   if (alIsBuffer(buffer))
     alDeleteBuffers(1, &buffer);
 }

--- a/src/engine/audio/Soundtrack.hxx
+++ b/src/engine/audio/Soundtrack.hxx
@@ -66,11 +66,11 @@ struct Soundtrack
   bool isPlayable : 1;
 
   /**
-   * @brief The OpenAL source of the sound track
+   * @brief The OpenAL sources of the sound track
    * @details An object that tells the OpenAL system where the sound making object is located in 3D space
-   * and what buffer(sound) it makes.
+   * and what buffer(sound) it makes. source[0] is for sound effects and source[1] is for music.
    */
-  ALuint source;
+  ALuint source[2];
 
   /**
    * @brief The OpenAL buffer of the sound track

--- a/src/services/AudioMixer.cxx
+++ b/src/services/AudioMixer.cxx
@@ -138,21 +138,20 @@ SoundtrackUPtr &AudioMixer::getTrack(const SoundtrackID &id)
 
 void AudioMixer::setMusicVolume(float volume)
 {
-  // alSourcef(currentSourceID, AL_GAIN, newVolume);
-  // this would set the volume, but idk how to get the "currentSourceID"
-
-  // for now set the volume for everything.
-  alListenerf(AL_GAIN, volume);
+  for (auto it : m_Playing)
+  {
+    alSourcef((**it).source[1], AL_GAIN, volume);
+  }
   // update the settings accordingly
   Settings::instance().musicVolume = volume;
 }
 
 void AudioMixer::setSoundEffectVolume(float volume)
 {
-  // find out how to set those volumes seperately
-  //alListenerf(AL_GAIN, volume);
-  
-  // for now, just set the settings value, even if it doesnt do anything
+  for (auto it : m_Playing)
+  {
+    alSourcef((**it).source[0], AL_GAIN, volume);
+  }
   Settings::instance().soundEffectsVolume = volume;
 }
 
@@ -179,8 +178,10 @@ void AudioMixer::play(const SoundtrackID &id, const Coordinate3D &position)
   auto &track = getTrack(id);
   if (track)
   {
-    /* set position of source in track */
-    alSource3f(track->source, AL_POSITION, static_cast<ALfloat>(position.x), static_cast<ALfloat>(position.y),
+    /* set position of sources in track */
+    alSource3f(track->source[0], AL_POSITION, static_cast<ALfloat>(position.x), static_cast<ALfloat>(position.y),
+               static_cast<ALfloat>(position.z));
+    alSource3f(track->source[1], AL_POSITION, static_cast<ALfloat>(position.x), static_cast<ALfloat>(position.y),
                static_cast<ALfloat>(position.z));
     playSoundtrack(track);
   }
@@ -191,9 +192,11 @@ void AudioMixer::play(const AudioTrigger &trigger, const Coordinate3D &position)
   auto &track = getTrack(trigger);
   if (track)
   {
-    /* set position of source in track
+    /* set position of sources in track
    * converted to regular Cartesian coordinate system */
-    alSource3f(track->source, AL_POSITION, static_cast<ALfloat>(position.x), static_cast<ALfloat>(position.y),
+    alSource3f(track->source[0], AL_POSITION, static_cast<ALfloat>(position.x), static_cast<ALfloat>(position.y),
+               static_cast<ALfloat>(position.z));
+    alSource3f(track->source[1], AL_POSITION, static_cast<ALfloat>(position.x), static_cast<ALfloat>(position.y),
                static_cast<ALfloat>(position.z));
     playSoundtrack(track);
   }
@@ -240,8 +243,10 @@ void AudioMixer::play(const SoundtrackID &id, const Coordinate3D &position, cons
   auto &track = getTrack(id);
   if (track)
   {
-    /* set position of source in track */
-    alSource3f(track->source, AL_POSITION, static_cast<ALfloat>(position.x), static_cast<ALfloat>(position.y),
+    /* set position of sources in track */
+    alSource3f(track->source[0], AL_POSITION, static_cast<ALfloat>(position.x), static_cast<ALfloat>(position.y),
+               static_cast<ALfloat>(position.z));
+    alSource3f(track->source[1], AL_POSITION, static_cast<ALfloat>(position.x), static_cast<ALfloat>(position.y),
                static_cast<ALfloat>(position.z));
     playSoundtrackWithReverb(track, reverb_properties);
   }
@@ -252,8 +257,10 @@ void AudioMixer::play(const SoundtrackID &id, const Coordinate3D &position, cons
   auto &track = getTrack(id);
   if (track)
   {
-    /* set position of source in track */
-    alSource3f(track->source, AL_POSITION, static_cast<ALfloat>(position.x), static_cast<ALfloat>(position.y),
+    /* set position of sources in track */
+    alSource3f(track->source[0], AL_POSITION, static_cast<ALfloat>(position.x), static_cast<ALfloat>(position.y),
+               static_cast<ALfloat>(position.z));
+    alSource3f(track->source[1], AL_POSITION, static_cast<ALfloat>(position.x), static_cast<ALfloat>(position.y),
                static_cast<ALfloat>(position.z));
     playSoundtrackWithEcho(track, echo_properties);
   }
@@ -265,8 +272,10 @@ void AudioMixer::play(const AudioTrigger &trigger, const Coordinate3D &position,
   auto &track = getTrack(trigger);
   if (track)
   {
-    /* set position of source in track converted to regular Cartesian coordinate system */
-    alSource3f(track->source, AL_POSITION, static_cast<ALfloat>(position.x), static_cast<ALfloat>(position.y),
+    /* set position of sources in track converted to regular Cartesian coordinate system */
+    alSource3f(track->source[0], AL_POSITION, static_cast<ALfloat>(position.x), static_cast<ALfloat>(position.y),
+               static_cast<ALfloat>(position.z));
+    alSource3f(track->source[1], AL_POSITION, static_cast<ALfloat>(position.x), static_cast<ALfloat>(position.y),
                static_cast<ALfloat>(position.z));
     playSoundtrackWithReverb(track, reverb_properties);
   }
@@ -277,9 +286,11 @@ void AudioMixer::play(const AudioTrigger &trigger, const Coordinate3D &position,
   auto &track = getTrack(trigger);
   if (track)
   {
-    /* set position of source in track
+    /* set position of sources in track
    * converted to regular Cartesian coordinate system */
-    alSource3f(track->source, AL_POSITION, static_cast<ALfloat>(position.x), static_cast<ALfloat>(position.y),
+    alSource3f(track->source[0], AL_POSITION, static_cast<ALfloat>(position.x), static_cast<ALfloat>(position.y),
+               static_cast<ALfloat>(position.z));
+    alSource3f(track->source[1], AL_POSITION, static_cast<ALfloat>(position.x), static_cast<ALfloat>(position.y),
                static_cast<ALfloat>(position.z));
     playSoundtrackWithEcho(track, echo_properties);
   }
@@ -297,7 +308,8 @@ void AudioMixer::stopAll()
   while (!m_Playing.empty())
   {
     auto it = m_Playing.begin();
-    alSourceStop((**it)->source);
+    alSourceStop((**it)->source[0]);
+    alSourceStop((**it)->source[1]);
     (**it)->isPlaying = false;
     m_Playing.erase(it);
   }
@@ -313,7 +325,7 @@ void AudioMixer::prune()
   for (auto it = m_Playing.begin(); it != m_Playing.end();)
   {
     int state = 0;
-    alGetSourcei((**it)->source, AL_SOURCE_STATE, &state);
+    alGetSourcei((**it)->source[(**it)->isMusic], AL_SOURCE_STATE, &state);
     if (state != AL_PLAYING)
     {
       (**it)->isPlaying = false;
@@ -339,7 +351,8 @@ void AudioMixer::playSoundtrack(SoundtrackUPtr &track)
 
   if (!track->source)
     throw AudioError{TRACE_INFO "Unable to play track because its source is uninitialized"};
-  alSourcePlay(track->source);
+
+  alSourcePlay(track->source[track->isMusic]);
 
   m_Playing.push_front(&track);
   track->isPlaying = true;
@@ -471,12 +484,12 @@ void AudioMixer::playSoundtrackWithReverb(SoundtrackUPtr &track, const StandardR
   alDeleteEffects(1, &effect);
 
   //apply effect to source
-  alSource3i(track->source, AL_AUXILIARY_SEND_FILTER, (ALint)(track->effect_slot), 0, AL_FILTER_NULL);
+  alSource3i(track->source[track->isMusic], AL_AUXILIARY_SEND_FILTER, (ALint)(track->effect_slot), 0, AL_FILTER_NULL);
   assert(alGetError() == AL_NO_ERROR && "Failed to setup reverb for sound source send 0.");
 
   //play sound
 
-  alSourcePlay(track->source);
+  alSourcePlay(track->source[track->isMusic]);
 
   m_Playing.push_front(&track);
   track->isPlaying = true;
@@ -557,12 +570,12 @@ void AudioMixer::playSoundtrackWithEcho(SoundtrackUPtr &track, const EchoPropert
   alDeleteEffects(1, &effect);
 
   //apply effect to source
-  alSource3i(track->source, AL_AUXILIARY_SEND_FILTER, (ALint)(track->effect_slot), 0, AL_FILTER_NULL);
+  alSource3i(track->source[track->isMusic], AL_AUXILIARY_SEND_FILTER, (ALint)(track->effect_slot), 0, AL_FILTER_NULL);
   assert(alGetError() == AL_NO_ERROR && "Failed to setup reverb for sound source send 0.");
 
   //play sound
 
-  alSourcePlay(track->source);
+  alSourcePlay(track->source[track->isMusic]);
 
   m_Playing.push_front(&track);
   track->isPlaying = true;


### PR DESCRIPTION
Now you can adjust music volume and SFX volume separately. Will add the slider to the user interface in settings in another commit, but for now you can test this by entering the game, turning the music volume down to zero, and you can still hear the wind and nature sounds. 