### PR TITLE
Implemented "level terrain" feature, fix #28

### DIFF
--- a/src/engine/EventManager.cxx
+++ b/src/engine/EventManager.cxx
@@ -55,21 +55,21 @@ void EventManager::pickTileUnderCursor(Point mouseIsoCoords)
   // update placement mode
   switch (topMostActiveLayer)
   {
-    case Layer::BUILDINGS:
-      GameStates::instance().placementMode = PlacementMode::SINGLE;
-      break;
-    case Layer::ROAD:
-    case Layer::POWERLINES:
-    case Layer::UNDERGROUND:
-      GameStates::instance().placementMode = PlacementMode::LINE;
-      break;
-    case Layer::GROUND_DECORATION:
-    case Layer::WATER:
-    case Layer::ZONE:
-      GameStates::instance().placementMode = PlacementMode::RECTANGLE;
-      break;
-    default:
-      break;
+  case Layer::BUILDINGS:
+    GameStates::instance().placementMode = PlacementMode::SINGLE;
+    break;
+  case Layer::ROAD:
+  case Layer::POWERLINES:
+  case Layer::UNDERGROUND:
+    GameStates::instance().placementMode = PlacementMode::LINE;
+    break;
+  case Layer::GROUND_DECORATION:
+  case Layer::WATER:
+  case Layer::ZONE:
+    GameStates::instance().placementMode = PlacementMode::RECTANGLE;
+    break;
+  default:
+    break;
   }
   mapNodeData = node.getMapNodeData();
   tileToPlace = mapNodeData[topMostActiveLayer].tileID;
@@ -408,7 +408,7 @@ void EventManager::checkEvents(SDL_Event &event)
       break;
     case SDL_MOUSEBUTTONDOWN:
       m_placementAllowed = false;
-      
+
       if (event.button.button == SDL_BUTTON_RIGHT)
       {
         m_panning = true;
@@ -488,6 +488,10 @@ void EventManager::checkEvents(SDL_Event &event)
         {
           MapFunctions::instance().changeHeight(mouseIsoCoords, false);
         }
+        else if (terrainEditMode == TerrainEdit::LEVEL)
+        {
+          MapFunctions::instance().levelHeight(m_clickDownCoords, m_nodesToPlace);
+        }
         else if (demolishMode)
         {
           MapFunctions::instance().demolishNode(m_nodesToHighlight, true);
@@ -518,7 +522,8 @@ void EventManager::checkEvents(SDL_Event &event)
       if (highlightSelection)
       {
         m_nodesToHighlight.push_back(mouseIsoCoords);
-        if (!uiManager.isMouseHovered() && !tileToPlace.empty() && !MapFunctions::instance().setTileID(tileToPlace, mouseIsoCoords))
+        if (!uiManager.isMouseHovered() && !tileToPlace.empty() &&
+            !MapFunctions::instance().setTileID(tileToPlace, mouseIsoCoords))
         {
           MapFunctions::instance().highlightNode(mouseIsoCoords, SpriteHighlightColor::RED);
         }

--- a/src/engine/map/MapFunctions.cxx
+++ b/src/engine/map/MapFunctions.cxx
@@ -13,10 +13,7 @@
 #include <set>
 #include <queue>
 
-MapFunctions::MapFunctions()
-{
-  SignalMediator::instance().registerCbSaveGame(Signal::slot(this, &MapFunctions::saveMapToFile));
-}
+MapFunctions::MapFunctions() { SignalMediator::instance().registerCbSaveGame(Signal::slot(this, &MapFunctions::saveMapToFile)); }
 
 bool MapFunctions::updateHeight(Point coordinate, const bool elevate)
 {
@@ -61,6 +58,77 @@ void MapFunctions::changeHeight(const Point &isoCoordinates, const bool elevate)
     demolishNode(neighorCoordinates);
     updateNodeNeighbors(nodesToUpdate);
   }
+}
+
+void MapFunctions::levelHeight(const Point &startCoordinate, const Vector<Point> levelArea)
+{
+  const MapNode &startNode = getMapNode(startCoordinate);
+  int initialHeight = startCoordinate.height;
+
+  /* If the initial node is sloped, check if a majority of it's neighbors,
+	* not counting other sloped nodes are elevated.
+	* If so, the initial node should be regarded as elevated too,
+	* i.e. the height should be incremented.
+	* This seems to yield the most intuitive behavior on slopes.
+	*/
+  if (startNode.isSlopeNode())
+  {
+    char directNeighbors =
+        NeighborNodesPosition::LEFT | NeighborNodesPosition::TOP | NeighborNodesPosition::RIGHT | NeighborNodesPosition::BOTTOM;
+    char elBitmask = startNode.getElevationBitmask();
+
+    int nonSelectedNeighborsCount = 0;
+    int elevatedNonSelectedNeighborsCount = 0;
+
+    for (Point neighbor : PointFunctions::getNeighbors(startCoordinate, false))
+    {
+      const NeighborNodesPosition neighborPosToOrigin = PointFunctions::getNeighborPositionToOrigin(neighbor, startCoordinate);
+      const bool isSloped = getMapNode(neighbor).isSlopeNode();
+
+      // Only look at non-sloped direct neighbors not in the selection.
+      if (!isSloped && (neighborPosToOrigin & directNeighbors) > 0 &&
+          std::find(levelArea.begin(), levelArea.end(), neighbor) == levelArea.end())
+      {
+        nonSelectedNeighborsCount++;
+
+        if ((neighborPosToOrigin & elBitmask) > 0)
+          elevatedNonSelectedNeighborsCount++;
+      }
+    }
+
+    if (elevatedNonSelectedNeighborsCount * 2 > nonSelectedNeighborsCount)
+      // No need to check max height since there are elevated neighbors.
+      initialHeight++;
+  }
+
+  Vector<Point> neighborsToLower;
+
+  for (const Point &levelPoint : levelArea)
+  {
+    // If a node gets lowered, save all it's neighbors to be lowered aswell.
+    // We have to get the node first, since the coordinates in the area are generated with height=0
+    if (getMapNode(levelPoint).getCoordinates().height > initialHeight)
+    {
+      // This possibly stores nodes that have already been processed for another round.
+      // It's faster than checking if each node is in levelArea first though.
+      Vector<Point> neighbors = PointFunctions::getNeighbors(levelPoint, false);
+      neighborsToLower.insert(neighborsToLower.end(), neighbors.begin(), neighbors.end());
+    }
+
+    Point newCoordinates = Point(levelPoint.x, levelPoint.y, levelPoint.z, initialHeight);
+    MapNode &levelNode = getMapNode(levelPoint);
+    levelNode.setCoordinates(newCoordinates);
+  }
+
+  for (const Point &levelPoint : neighborsToLower)
+  {
+    Point newCoordinates = Point(levelPoint.x, levelPoint.y, levelPoint.z, initialHeight);
+    MapNode &levelNode = getMapNode(levelPoint);
+    levelNode.setCoordinates(newCoordinates);
+  }
+
+  updateNodeNeighbors(levelArea);
+  updateNodeNeighbors(neighborsToLower);
 }
 
 void MapFunctions::updateNodeNeighbors(const std::vector<Point> &nodes)

--- a/src/engine/map/MapFunctions.cxx
+++ b/src/engine/map/MapFunctions.cxx
@@ -60,7 +60,7 @@ void MapFunctions::changeHeight(const Point &isoCoordinates, const bool elevate)
   }
 }
 
-void MapFunctions::levelHeight(const Point &startCoordinate, const Vector<Point> levelArea)
+void MapFunctions::levelHeight(const Point &startCoordinate, const std::vector<Point> levelArea)
 {
   const MapNode &startNode = getMapNode(startCoordinate);
   int initialHeight = startCoordinate.height;

--- a/src/engine/map/MapFunctions.hxx
+++ b/src/engine/map/MapFunctions.hxx
@@ -3,6 +3,7 @@
 
 // #include "WindowManager.hxx"
 // #include "basics/Point.hxx"
+#include <vector>
 #include "../Map.hxx"
 // #include "../../util/Singleton.hxx"
 #include <Singleton.hxx>
@@ -31,7 +32,7 @@ public:
 	* @param startcoordinate the starting point whose height is used for levelling
 	* @param levelArea the area that is to be leveled.
 	*/
-  void levelHeight(const Point &startCoordinate, const Vector<Point> levelArea);
+  void levelHeight(const Point &startCoordinate, const std::vector<Point> levelArea);
 
   /** \brief Get pointer to a single mapNode at specific iso coordinates.
   * @param isoCoords The node to retrieve.

--- a/src/engine/map/MapFunctions.hxx
+++ b/src/engine/map/MapFunctions.hxx
@@ -4,7 +4,6 @@
 // #include "WindowManager.hxx"
 // #include "basics/Point.hxx"
 #include "../Map.hxx"
-#include "audio/AudioConfig.hxx"
 // #include "../../util/Singleton.hxx"
 #include <Singleton.hxx>
 #include <Point.hxx>

--- a/src/engine/map/MapFunctions.hxx
+++ b/src/engine/map/MapFunctions.hxx
@@ -4,6 +4,7 @@
 // #include "WindowManager.hxx"
 // #include "basics/Point.hxx"
 #include "../Map.hxx"
+#include "audio/AudioConfig.hxx"
 // #include "../../util/Singleton.hxx"
 #include <Singleton.hxx>
 #include <Point.hxx>
@@ -26,6 +27,12 @@ public:
   * @return true in case that height has been changed, otherwise false.
   */
   bool updateHeight(Point coordinate, const bool elevate);
+
+  /** \brief level area of map nodes.
+	* @param startcoordinate the starting point whose height is used for levelling
+	* @param levelArea the area that is to be leveled.
+	*/
+  void levelHeight(const Point &startCoordinate, const Vector<Point> levelArea);
 
   /** \brief Get pointer to a single mapNode at specific iso coordinates.
   * @param isoCoords The node to retrieve.

--- a/src/game/ui/BuildMenu.cxx
+++ b/src/game/ui/BuildMenu.cxx
@@ -17,7 +17,11 @@ namespace ui = ImGui;
 BuildMenu::BuildMenu()
 {
   // function create new big category button
-  auto main_button = [this] (const char *tx, const char *id) { m_buttons.emplace_back(std::make_shared<BuildMenuButton>(tx, id)); return m_buttons.back(); };
+  auto main_button = [this](const char *tx, const char *id)
+  {
+    m_buttons.emplace_back(std::make_shared<BuildMenuButton>(tx, id));
+    return m_buttons.back();
+  };
 
   // special case for construction button
   auto constrution = main_button("Button_ConstructionMenu", "Construction");
@@ -37,7 +41,7 @@ BuildMenu::BuildMenu()
   main_button("Button_WaterMenu", "Waterworks");
   main_button("Button_EmergencyMenu", "Emergency");
   main_button("Button_DebugMenu", "Debug");
-  
+
   // save texture size
   ImSpan2i size;
   SDL_QueryTexture(m_buttons.front()->m_tex, nullptr, nullptr, &size.w, &size.h);
@@ -48,12 +52,11 @@ BuildMenu::BuildMenu()
 
 namespace detail
 {
-  float getItemSpan(int deep) { return deep == 0 ? 16.f : 6.f; }
-}
+float getItemSpan(int deep) { return deep == 0 ? 16.f : 6.f; }
+} // namespace detail
 
 // recusively draw categories
-template<class Holder>
-void drawSubmenu(ImVec2 pos, float categoryOffset, const Holder &holder, BuildMenu *menu, int deep)
+template <class Holder> void drawSubmenu(ImVec2 pos, float categoryOffset, const Holder &holder, BuildMenu *menu, int deep)
 {
   if (holder.getButtons().empty())
     return;
@@ -68,20 +71,25 @@ void drawSubmenu(ImVec2 pos, float categoryOffset, const Holder &holder, BuildMe
   ImVec2 itemSpacing;
   ImVec2 nextPos;
   ImVec2 nextOffset{0, 0};
-  bool verticalMenu = (uiManager.buildMenuLayout() == BUILDMENU_LAYOUT::LEFT || uiManager.buildMenuLayout() == BUILDMENU_LAYOUT::RIGHT);
-  itemSpacing = verticalMenu
-                    ? itemSpacing = ImVec2(0, detail::getItemSpan(deep))
-                    : ImVec2(detail::getItemSpan(deep), 0);
-  windowSize = verticalMenu
-                    ? ImVec2(frameSize.x, frameFullWidth * (float)holder.getButtons().size())
-                    : ImVec2(frameFullWidth * (float)holder.getButtons().size(), frameSize.y);
-  
+  bool verticalMenu =
+      (uiManager.buildMenuLayout() == BUILDMENU_LAYOUT::LEFT || uiManager.buildMenuLayout() == BUILDMENU_LAYOUT::RIGHT);
+  itemSpacing = verticalMenu ? itemSpacing = ImVec2(0, detail::getItemSpan(deep)) : ImVec2(detail::getItemSpan(deep), 0);
+  windowSize = verticalMenu ? ImVec2(frameSize.x, frameFullWidth * (float)holder.getButtons().size())
+                            : ImVec2(frameFullWidth * (float)holder.getButtons().size(), frameSize.y);
+
   switch (uiManager.buildMenuLayout())
   {
-    case BUILDMENU_LAYOUT::BOTTOM: nextOffset.y = -categoryOffset; break;
-    case BUILDMENU_LAYOUT::TOP: nextOffset.y = +categoryOffset; break;
-    case BUILDMENU_LAYOUT::LEFT: nextOffset.x = categoryOffset; break;
-    default: nextOffset.x = -categoryOffset;
+  case BUILDMENU_LAYOUT::BOTTOM:
+    nextOffset.y = -categoryOffset;
+    break;
+  case BUILDMENU_LAYOUT::TOP:
+    nextOffset.y = +categoryOffset;
+    break;
+  case BUILDMENU_LAYOUT::LEFT:
+    nextOffset.x = categoryOffset;
+    break;
+  default:
+    nextOffset.x = -categoryOffset;
   }
 
   const auto &layout = uiManager.getLayouts()["BuildMenuButtons"];
@@ -100,13 +108,15 @@ void drawSubmenu(ImVec2 pos, float categoryOffset, const Holder &holder, BuildMe
   bool open = true;
   std::string wId = std::string("##BuildMenu_") + holder.getId() + std::to_string(deep);
   // begin buttons
-  ui::Begin(wId.c_str(), &open, ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
+  ui::Begin(wId.c_str(), &open,
+            ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoScrollbar |
+                ImGuiWindowFlags_NoScrollWithMouse);
 
   // setup screen size cliip rect that handle mouse event outside
   ui::PushClipRect(ImVec2{0, 0}, screenSize, false);
   BuildMenuButton::Ptr nextMenuLevel = nullptr;
   int idx = 0;
-  
+
   // draw buttons, each button need unique id
   std::array<char, 128> id_str = {0};
   for (auto btn : holder.getButtons())
@@ -115,11 +125,11 @@ void drawSubmenu(ImVec2 pos, float categoryOffset, const Holder &holder, BuildMe
 
     ImVec2 imgPos{btn->m_destRect.x, btn->m_destRect.y};
     ImVec2 imgSize{btn->m_destRect.z, btn->m_destRect.w};
-    
+
     // draw bg | pressed state
     ImGuiButtonFlags flags = btn->m_open ? ImGuiButtonFlags_ForcePressed : 0;
     flags |= btn->m_background ? 0 : ImGuiButtonFlags_NoBackground;
-    
+
     if (ui::ImageButtonCt(btn->m_tex, flags, frameSize, imgPos, imgSize, btn->m_uv0, btn->m_uv1, -1, ImVec4(0, 0, 0, 0)))
     {
       btn->m_open = !btn->m_open;
@@ -130,7 +140,7 @@ void drawSubmenu(ImVec2 pos, float categoryOffset, const Holder &holder, BuildMe
     if (ui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && ui::GetHoveredTimer() > menu->getTooltipDelay())
     {
       ui::SetTooltip(btn->getId().c_str());
-    } 
+    }
 
     // calc next subcategory position center
     if (btn->m_open && !btn->getButtons().empty())
@@ -142,21 +152,21 @@ void drawSubmenu(ImVec2 pos, float categoryOffset, const Holder &holder, BuildMe
 
       switch (uiManager.buildMenuLayout())
       {
-        case BUILDMENU_LAYOUT::BOTTOM:
-          nextPos.x = ui::GetCursorScreenPos().x + ((float)(idx - 1) * frameFullWidth) - nextCategoryOffset + frameFullWidth / 2;
-          nextPos.y = pos.y - nextFrameFullWidth;
+      case BUILDMENU_LAYOUT::BOTTOM:
+        nextPos.x = ui::GetCursorScreenPos().x + ((float)(idx - 1) * frameFullWidth) - nextCategoryOffset + frameFullWidth / 2;
+        nextPos.y = pos.y - nextFrameFullWidth;
         break;
-        case BUILDMENU_LAYOUT::TOP:
-          nextPos.x = ui::GetCursorScreenPos().x + ((float)(idx - 1) * frameFullWidth) - nextCategoryOffset + frameFullWidth / 2;
-          nextPos.y = pos.y + frameFullWidth + detail::getItemSpan(1);
+      case BUILDMENU_LAYOUT::TOP:
+        nextPos.x = ui::GetCursorScreenPos().x + ((float)(idx - 1) * frameFullWidth) - nextCategoryOffset + frameFullWidth / 2;
+        nextPos.y = pos.y + frameFullWidth + detail::getItemSpan(1);
         break;
-        case BUILDMENU_LAYOUT::LEFT:
-          nextPos.x = pos.x + frameFullWidth + detail::getItemSpan(1);
-          nextPos.y = ui::GetCursorScreenPos().y - nextCategoryOffset - frameFullWidth / 2;
+      case BUILDMENU_LAYOUT::LEFT:
+        nextPos.x = pos.x + frameFullWidth + detail::getItemSpan(1);
+        nextPos.y = ui::GetCursorScreenPos().y - nextCategoryOffset - frameFullWidth / 2;
         break;
-        default:
-          nextPos.x = pos.x - nextFrameFullWidth;
-          nextPos.y = ui::GetCursorScreenPos().y - nextCategoryOffset - frameFullWidth / 2;
+      default:
+        nextPos.x = pos.x - nextFrameFullWidth;
+        nextPos.y = ui::GetCursorScreenPos().y - nextCategoryOffset - frameFullWidth / 2;
         break;
       }
     }
@@ -168,7 +178,7 @@ void drawSubmenu(ImVec2 pos, float categoryOffset, const Holder &holder, BuildMe
   }
 
   ui::PopClipRect(); // back common clip rect
-  
+
   ui::End(); // end buttons
 
   ui::PopStyleVar(4);
@@ -180,20 +190,29 @@ void drawSubmenu(ImVec2 pos, float categoryOffset, const Holder &holder, BuildMe
   }
 }
 
-void BuildMenu::draw() const {
+void BuildMenu::draw() const
+{
   ImVec2 screenSize = ui::GetIO().DisplaySize;
-  auto _self = const_cast<BuildMenu *>(this);  // const_cast here because button open state can be changed
+  auto _self = const_cast<BuildMenu *>(this); // const_cast here because button open state can be changed
 
   ImVec2 pos{0, 0};
   const auto &uiManager = UIManager::instance();
   const float frameSize = m_btnSize.x + detail::getItemSpan(0);
   const float buttonsSize = (float)m_buttons.size();
 
-  switch (uiManager.buildMenuLayout()) {
-    case BUILDMENU_LAYOUT::BOTTOM: pos = { (screenSize.x -  buttonsSize * frameSize) / 2, screenSize.y - m_btnSize.y}; break;
-    case BUILDMENU_LAYOUT::TOP: pos = ImVec2{(screenSize.x - buttonsSize * frameSize) / 2, 0}; break;
-    case BUILDMENU_LAYOUT::LEFT: pos = ImVec2{0, (screenSize.y - buttonsSize * frameSize) / 2}; break;
-    default: pos = {screenSize.x - m_btnSize.x, (screenSize.y - buttonsSize * frameSize) / 2};
+  switch (uiManager.buildMenuLayout())
+  {
+  case BUILDMENU_LAYOUT::BOTTOM:
+    pos = {(screenSize.x - buttonsSize * frameSize) / 2, screenSize.y - m_btnSize.y};
+    break;
+  case BUILDMENU_LAYOUT::TOP:
+    pos = ImVec2{(screenSize.x - buttonsSize * frameSize) / 2, 0};
+    break;
+  case BUILDMENU_LAYOUT::LEFT:
+    pos = ImVec2{0, (screenSize.y - buttonsSize * frameSize) / 2};
+    break;
+  default:
+    pos = {screenSize.x - m_btnSize.x, (screenSize.y - buttonsSize * frameSize) / 2};
   }
 
   drawSubmenu(pos, frameSize, *this, _self, 0);
@@ -201,14 +220,14 @@ void BuildMenu::draw() const {
 
 void BuildMenu::createSubMenus()
 {
-  auto debugBtnIt = std::find_if(m_buttons.begin(), m_buttons.end(), [] (auto &btn) { return btn->getId() == "Debug"; });
+  auto debugBtnIt = std::find_if(m_buttons.begin(), m_buttons.end(), [](auto &btn) { return btn->getId() == "Debug"; });
   if (debugBtnIt == m_buttons.end())
   {
     return;
   }
 
   std::map<std::string, BuildMenuButton::Ptr> categories;
-  for (auto btn: m_buttons)
+  for (auto btn : m_buttons)
   {
     categories[btn->getId()] = btn;
   }
@@ -216,13 +235,10 @@ void BuildMenu::createSubMenus()
   for (const auto &[tx, tileData] : TileManager::instance().getAllTileData())
   {
     const std::string &category = tileData.category;
-    const std::string subCategory = (tileData.subCategory == tileData.category) ? (tileData.category + "_" + tileData.subCategory) : tileData.subCategory;
+    const std::string subCategory =
+        (tileData.subCategory == tileData.category) ? (tileData.category + "_" + tileData.subCategory) : tileData.subCategory;
     const std::string &title = tileData.title;
-    const std::string &tooltip = !title.empty()
-                                    ? title
-                                    : subCategory.empty()
-                                        ? category
-                                        : subCategory;
+    const std::string &tooltip = !title.empty() ? title : subCategory.empty() ? category : subCategory;
 
     // Skip all items that have no button group
     if (category == "Water" || category == "Terrain")
@@ -252,7 +268,7 @@ void BuildMenu::createSubMenus()
 
         subBtn->addTileButton(tx, tooltip, tileData);
       }
-      else 
+      else
       {
         it->second->addTileButton(tx, tooltip, tileData);
       }
@@ -328,7 +344,7 @@ void BuildMenu::onAction(const std::string &action, bool checked)
       GameStates::instance().demolishMode = DemolishMode::DEFAULT;
     }
   }
-  else if (action == "LowerTerrain") 
+  else if (action == "LowerTerrain")
   {
     terrainEditMode = checked ? TerrainEdit::LOWER : TerrainEdit::NONE;
     highlightSelection = checked;
@@ -336,6 +352,11 @@ void BuildMenu::onAction(const std::string &action, bool checked)
   else if (action == "RaiseTerrain")
   {
     terrainEditMode = checked ? TerrainEdit::RAISE : TerrainEdit::NONE;
+    highlightSelection = checked;
+  }
+  else if (action == "LevelTerrain")
+  {
+    terrainEditMode = checked ? TerrainEdit::LEVEL : TerrainEdit::NONE;
     highlightSelection = checked;
   }
   else if (action == "DeZone")
@@ -372,7 +393,7 @@ void BuildMenu::onChangeTileType(const std::string &actionParameter, bool checke
     tileToPlace = "";
     highlightSelection = false;
   }
-  
+
   tileToPlace = checked ? actionParameter : "";
   highlightSelection = checked;
   if (GameStates::instance().layerEditMode == LayerEditMode::BLUEPRINT)
@@ -390,13 +411,13 @@ void BuildMenu::onChangeTileType(const std::string &actionParameter, bool checke
       case +TileType::DEFAULT:
         GameStates::instance().placementMode = PlacementMode::SINGLE;
         break;
-      
+
       case +TileType::ROAD:
       case +TileType::AUTOTILE:
       case +TileType::POWERLINE:
         GameStates::instance().placementMode = PlacementMode::LINE;
         break;
-      
+
       case +TileType::GROUNDDECORATION:
       case +TileType::WATER:
       case +TileType::ZONE:
@@ -408,7 +429,7 @@ void BuildMenu::onChangeTileType(const std::string &actionParameter, bool checke
         GameStates::instance().layerEditMode = LayerEditMode::BLUEPRINT;
         MapLayers::setLayerEditMode(GameStates::instance().layerEditMode);
         break;
-      
+
       default:
         break;
       }
@@ -420,7 +441,7 @@ void BuildMenu::closeSubmenus()
 {
   clearState();
 
-  for (auto &btn: m_buttons)
+  for (auto &btn : m_buttons)
   {
     btn->hideItems();
   }
@@ -433,8 +454,7 @@ void BuildMenu::clearState()
   terrainEditMode = TerrainEdit::NONE;
 }
 
-BuildMenuButton::BuildMenuButton(const std::string &tx, const std::string &id) 
-                  : m_texstr(tx), m_id(id)
+BuildMenuButton::BuildMenuButton(const std::string &tx, const std::string &id) : m_texstr(tx), m_id(id)
 {
   m_tex = ResourcesManager::instance().getUITexture(tx);
   SDL_QueryTexture(m_tex, nullptr, nullptr, &m_texSize.w, &m_texSize.h);
@@ -443,7 +463,7 @@ BuildMenuButton::BuildMenuButton(const std::string &tx, const std::string &id)
 }
 
 BuildMenuButton::BuildMenuButton(const std::string &tx, const std::string &id, const TileData &tile)
-                   : m_background(true), m_texstr(tx), m_id(id), m_tiletype(tx)
+    : m_background(true), m_texstr(tx), m_id(id), m_tiletype(tx)
 {
   int bWid = Settings::instance().subMenuButtonWidth;  //UI button width for sub menues
   int bHei = Settings::instance().subMenuButtonHeight; //UI button height for sub menues
@@ -454,12 +474,14 @@ BuildMenuButton::BuildMenuButton(const std::string &tx, const std::string &id, c
   m_tex = TileManager::instance().getTexture(tx);
   SDL_QueryTexture(m_tex, nullptr, nullptr, &m_texSize.w, &m_texSize.h);
   m_uv0 = ImVec2((float)(tile.tiles.clippingWidth * tile.tiles.offset) / (float)m_texSize.w, 0.f);
-  m_uv1 = ImVec2(m_uv0.x + (float)(tile.tiles.clippingWidth) / (float)m_texSize.w, m_uv0.y + ((float)tile.tiles.clippingHeight) / (float)m_texSize.h);
+  m_uv1 = ImVec2(m_uv0.x + (float)(tile.tiles.clippingWidth) / (float)m_texSize.w,
+                 m_uv0.y + ((float)tile.tiles.clippingHeight) / (float)m_texSize.h);
   m_btnSize = ImVec2(bWid, bHei);
   m_destRect = ImVec4((float)destRect.x, (float)destRect.y, (float)destRect.w, (float)destRect.h);
 }
 
-BuildMenuButton::Ptr BuildMenuButton::addActionButton(const std::string &tx, const std::string &action, const std::string &tooltip)
+BuildMenuButton::Ptr BuildMenuButton::addActionButton(const std::string &tx, const std::string &action,
+                                                      const std::string &tooltip)
 {
   auto btn = std::make_shared<BuildMenuButton>(tx, action);
   btn->m_id = tooltip;


### PR DESCRIPTION
This is an overall naïve implementation, in the sense that it copies the height of the initial selected node and applies it to the whole area.

The main factors for code complexity stem from:
- my assumption that we want to level an arbitrary area and not always a rectangular area, which prevents some checks
- my personal requirements for levelling behavior on sloped nodes (see below)

The first point might be mitigated though by deciding on only having rectangular selection for levelling (see #1016).

## Sloped node behavior

Slopes should lower the terrain when the selection is pulled from the lower side:

![image](https://user-images.githubusercontent.com/53856770/185701963-c06a9657-ffa7-4fee-9510-fdd4ac5e9772.png)
levels to
![image](https://user-images.githubusercontent.com/53856770/185702024-ca3f3a6f-2fb7-4948-aca3-e0360483fc43.png)

They should raise the terrain when the selection goes the other way:

![image](https://user-images.githubusercontent.com/53856770/185702212-29198984-76fb-4cd5-8774-85138c6b0896.png)
levels to
![image](https://user-images.githubusercontent.com/53856770/185702309-fa381a16-b5a2-4c66-bacf-450a6712a8bf.png)

Edged slopes should behave the same:

![image](https://user-images.githubusercontent.com/53856770/185702477-b663a6f4-ab94-464f-bd2d-6a74d0c1118e.png)
levels to
![image](https://user-images.githubusercontent.com/53856770/185702563-fa2f8288-e088-4979-8c58-b33dac349ead.png)

In all screenshots the rectangle was dragged up from the lowest edge (I couldn't more meaningful screenshots, sorry).
