### PR TITLE
hotfix: restored missing NOISE_IN_SUBDIR `#include`-conditional code

### DIFF
--- a/src/engine/map/TerrainGenerator.cxx
+++ b/src/engine/map/TerrainGenerator.cxx
@@ -8,9 +8,11 @@
 #include <PointFunctions.hxx>
 
 #include "json.hxx"
-
+#ifdef NOISE_IN_SUBDIR
 #include <noise/noise.h>
-
+#else
+#include <noise.h>
+#endif
 #include <random>
 
 using json = nlohmann::json;


### PR DESCRIPTION
System: `Debian Sid`

Problem:
Cannot compile project.
On some systems, `noise.h` is not located & defined inside a `noise/` subdirectory.

Fix:
This PR restores missing conditional NOISE_IN_SUBDIR `#include`-code and fixed regression detected onwards from commit: [d1e96913](https://github.com/CytopiaTeam/Cytopia/commit/d1e9691307185c82c8b842d085933f41a256b822#diff-938dd938eb78b5ecdceb4eb96e55fdce187fa31c3cbd68bdc6d0c000c12d8225).