### PR TITLE
Fix strings incorrectly being passed as format strings

### DIFF
--- a/src/engine/UIManager.cxx
+++ b/src/engine/UIManager.cxx
@@ -200,7 +200,7 @@ void UIManager::drawUI()
   {
     ImVec2 pos = ui::GetMousePos();
     ui::SetCursorScreenPos(pos);
-    ui::Text(m_tooltip.c_str());
+    ui::Text("%s", m_tooltip.c_str());
   }
 
   if (m_showFpsCounter)
@@ -212,7 +212,7 @@ void UIManager::drawUI()
     ui::Begin("##fpswindow", &open,
               ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoScrollbar |
                   ImGuiWindowFlags_NoScrollWithMouse);
-    ui::Text(m_fpsCounter.c_str());
+    ui::Text("%s", m_fpsCounter.c_str());
     ui::SameLine();
     ui::Checkbox("debug", &m_showDebugMenu);
     ui::End();


### PR DESCRIPTION
I couldn't install the game from Arch Linux's AUR because, by default, it builds packages with `-Werror=format-security`. [This has been a problem before](https://github.com/CytopiaTeam/Cytopia/issues/1060), but this should fix the root cause for good.

In case it's not clear what the issue is, consider what happens if for some reason m_tooltip or m_fpsCounter has something like "%d" inside.